### PR TITLE
Fix header overlapping iOS status bar/notch area

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ html, body { margin: 0; padding: 0; background: #0a0e14; }
   }
   body { background: var(--bg); color: var(--text); font-family: var(--font-display); min-height: 100dvh; -webkit-user-select: none; user-select: none; -webkit-tap-highlight-color: transparent; }
   .app { max-width: 480px; margin: 0 auto; min-height: 100dvh; display: flex; flex-direction: column; }
-  .header { padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--surface2); }
+  .header { padding: calc(12px + env(safe-area-inset-top, 0px)) 16px 12px 16px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--surface2); }
   .header h1 { font-size: 14px; font-weight: 500; letter-spacing: 3px; text-transform: uppercase; color: var(--text-dim); }
   .header .live-dot { width: 8px; height: 8px; background: var(--accent); border-radius: 50%; animation: pulse 1.5s ease-in-out infinite; box-shadow: 0 0 8px var(--accent-glow); }
   @keyframes pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(0.8); } }


### PR DESCRIPTION
Add safe-area-inset-top padding to .header so the title and Import CSV button are reachable on iPhones with notch/Dynamic Island.

https://claude.ai/code/session_01JXkKbno2dB3RXEZNpekHoZ