### PR TITLE
v2.1: crash protection, autosave, CSV import, encoder backpressure fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,11 +247,12 @@ function generateSRT(pointLog, syncTimestamp, teamA, teamB) {
   return lines.join("\n");
 }
 
-function generateCSV(pointLog, syncTimestamp, teamA, teamB) {
-  var header = "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,ScoringTeam,Correction,ScoreDisplay";
+function generateCSV(pointLog, syncTimestamp, teamA, teamB, matchTitle) {
+  var header = "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,MatchTitle,ScoreDisplay";
   var rows = pointLog.map(function(p, i) {
     var offset = syncTimestamp ? p.timestamp - syncTimestamp : "";
-    return [i + 1, formatClockTime(p.wallClock), offset, p.setNum, p.pointsA, p.pointsB, p.team === "A" ? teamA : teamB, p.correction ? "Y" : "N", '"' + teamA + " " + p.pointsA + "-" + p.pointsB + " " + teamB + '"'].join(",");
+    var title = (matchTitle || "").replace(/"/g, '""');
+    return [i + 1, formatClockTime(p.wallClock), offset, p.setNum, p.pointsA, p.pointsB, p.setsA || 0, p.setsB || 0, p.team === "A" ? teamA : teamB, p.correction ? "Y" : "N", '"' + title + '"', '"' + teamA + " " + p.pointsA + "-" + p.pointsB + " " + teamB + '"'].join(",");
   });
   return [header].concat(rows).join("\n");
 }
@@ -736,10 +737,14 @@ function parseCSVToEntries(csvText, matchTitle) {
   var iPB = cols.indexOf("PointsB");
   var iCorr = cols.indexOf("Correction");
   var iDisplay = cols.indexOf("ScoreDisplay");
+  var iSA = cols.indexOf("SetsA");
+  var iSB = cols.indexOf("SetsB");
+  var iTitle = cols.indexOf("MatchTitle");
 
   if (iOffset === -1 || iSet === -1 || iPA === -1 || iPB === -1) {
     return { error: "CSV missing required columns: VideoOffset_ms, Set, PointsA, PointsB" };
   }
+  var hasSetsColumns = iSA !== -1 && iSB !== -1;
 
   // Extract team names from ScoreDisplay of first non-correction row
   var teamA = "Home", teamB = "Away";
@@ -769,22 +774,35 @@ function parseCSVToEntries(csvText, matchTitle) {
       setNum: parseInt(row[iSet], 10) || 1,
       pointsA: parseInt(row[iPA], 10) || 0,
       pointsB: parseInt(row[iPB], 10) || 0,
+      setsA: hasSetsColumns ? (parseInt(row[iSA], 10) || 0) : -1,
+      setsB: hasSetsColumns ? (parseInt(row[iSB], 10) || 0) : -1,
     });
   }
 
   if (dataRows.length === 0) return { error: "No valid data rows found in CSV." };
 
-  var title = (matchTitle || "").trim();
+  // Read MatchTitle from CSV if no explicit title provided
+  var csvTitle = "";
+  if (iTitle !== -1 && dataRows.length > 0) {
+    var firstRow = parseCSVRow(lines[1]);
+    csvTitle = (firstRow[iTitle] || "").replace(/"/g, "").trim();
+  }
+  var title = (matchTitle || csvTitle || "").trim();
 
-  // Calculate cumulative set wins from set transitions
+  // Build entries — use exact SetsA/SetsB from CSV when available, otherwise infer from set transitions
   var entries = [];
   var setsA = 0, setsB = 0, prevSetNum = 0, prevPointsA = 0, prevPointsB = 0;
   for (var j = 0; j < dataRows.length; j++) {
     var d = dataRows[j];
-    // When set number advances, the previous set ended — award it to the leader
-    if (d.setNum > prevSetNum && prevSetNum > 0) {
-      if (prevPointsA > prevPointsB) setsA++;
-      else if (prevPointsB > prevPointsA) setsB++;
+    if (hasSetsColumns) {
+      setsA = d.setsA;
+      setsB = d.setsB;
+    } else {
+      // Infer from set transitions for older CSVs without SetsA/SetsB columns
+      if (d.setNum > prevSetNum && prevSetNum > 0) {
+        if (prevPointsA > prevPointsB) setsA++;
+        else if (prevPointsB > prevPointsA) setsB++;
+      }
     }
     prevSetNum = d.setNum;
     prevPointsA = d.pointsA;
@@ -802,7 +820,7 @@ function parseCSVToEntries(csvText, matchTitle) {
     });
   }
 
-  return { entries: entries, teamA: teamA, teamB: teamB, rowCount: dataRows.length };
+  return { entries: entries, teamA: teamA, teamB: teamB, rowCount: dataRows.length, csvTitle: csvTitle };
 }
 
 function parseCSVRow(line) {
@@ -1323,7 +1341,7 @@ function VolleyballTracker() {
       fname = "generate_overlay.sh";
       if (!content) { window.alert("No sync point set or no points recorded."); return; }
     } else {
-      content = generateCSV(state.pointLog, state.syncTimestamp, state.teamA, state.teamB);
+      content = generateCSV(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle);
       fname += ".csv";
     }
     setCopyFeedback("");
@@ -1347,7 +1365,7 @@ function VolleyballTracker() {
   }
 
   function downloadCSV() {
-    var content = generateCSV(state.pointLog, state.syncTimestamp, state.teamA, state.teamB);
+    var content = generateCSV(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle);
     var fname = "scorelayer_" + state.teamA + "_vs_" + state.teamB + ".csv";
     var blob = new Blob([content], { type: "text/csv" });
     shareOrDownload(blob, fname, "text/csv");
@@ -1390,7 +1408,9 @@ function VolleyballTracker() {
     var text = e.target.value;
     setCsvText(text);
     if (text.trim().length > 20) {
-      setCsvParseResult(parseCSVToEntries(text));
+      var parsed = parseCSVToEntries(text);
+      setCsvParseResult(parsed);
+      if (parsed.csvTitle && !csvMatchTitle) setCsvMatchTitle(parsed.csvTitle);
     } else {
       setCsvParseResult(null);
     }
@@ -1403,7 +1423,9 @@ function VolleyballTracker() {
     reader.onload = function() {
       var text = reader.result;
       setCsvText(text);
-      setCsvParseResult(parseCSVToEntries(text));
+      var parsed = parseCSVToEntries(text);
+      setCsvParseResult(parsed);
+      if (parsed.csvTitle) setCsvMatchTitle(parsed.csvTitle);
     };
     reader.readAsText(file);
   }

--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle) 
 
 
 // --- CSV parser (for import/recovery) ---
-function parseCSVToEntries(csvText) {
+function parseCSVToEntries(csvText, matchTitle) {
   var lines = csvText.trim().split("\n");
   if (lines.length < 2) return { error: "CSV must have a header row and at least one data row." };
 
@@ -774,9 +774,21 @@ function parseCSVToEntries(csvText) {
 
   if (dataRows.length === 0) return { error: "No valid data rows found in CSV." };
 
+  var title = (matchTitle || "").trim();
+
+  // Calculate cumulative set wins from set transitions
   var entries = [];
+  var setsA = 0, setsB = 0, prevSetNum = 0, prevPointsA = 0, prevPointsB = 0;
   for (var j = 0; j < dataRows.length; j++) {
     var d = dataRows[j];
+    // When set number advances, the previous set ended — award it to the leader
+    if (d.setNum > prevSetNum && prevSetNum > 0) {
+      if (prevPointsA > prevPointsB) setsA++;
+      else if (prevPointsB > prevPointsA) setsB++;
+    }
+    prevSetNum = d.setNum;
+    prevPointsA = d.pointsA;
+    prevPointsB = d.pointsB;
     var startSec = d.offset_ms / 1000;
     var endSec = j < dataRows.length - 1 ? dataRows[j + 1].offset_ms / 1000 : startSec + 10;
     if (startSec < 0) continue;
@@ -785,8 +797,8 @@ function parseCSVToEntries(csvText) {
       end: Math.round(endSec * 1000) / 1000,
       score: teamA + "  " + d.pointsA + " : " + d.pointsB + "  " + teamB,
       set_info: "Set " + d.setNum,
-      title: "",
-      sets_score: ""
+      title: title,
+      sets_score: "Sets " + setsA + ":" + setsB
     });
   }
 
@@ -1144,6 +1156,7 @@ function VolleyballTracker() {
   const [csvIsEncoding, setCsvIsEncoding] = useState(false);
   const [csvEncodeProgress, setCsvEncodeProgress] = useState(0);
   const [csvPositionTop, setCsvPositionTop] = useState(true);
+  const [csvMatchTitle, setCsvMatchTitle] = useState("");
 
   // Autosave indicator
   const [showAutosaved, setShowAutosaved] = useState(false);
@@ -1398,11 +1411,15 @@ function VolleyballTracker() {
   async function handleCSVGenerateMP4() {
     if (!csvParseResult || !csvParseResult.entries || csvIsEncoding) return;
 
+    // Re-parse with current title so overlay includes it
+    var finalResult = parseCSVToEntries(csvText, csvMatchTitle);
+    if (!finalResult.entries) finalResult = csvParseResult;
+
     setCsvIsEncoding(true);
     setCsvEncodeProgress(0);
 
     var result = await generateOverlayMP4(
-      csvParseResult.entries, csvParseResult.teamA, csvParseResult.teamB,
+      finalResult.entries, finalResult.teamA, finalResult.teamB,
       csvPositionTop, function(pct) { setCsvEncodeProgress(pct); }
     );
 
@@ -1499,6 +1516,16 @@ function VolleyballTracker() {
               <div className="parsed-info">
                 Parsed <strong>{csvParseResult.rowCount}</strong> score entries for <strong>{csvParseResult.teamA}</strong> vs <strong>{csvParseResult.teamB}</strong>.
                 Duration: ~{Math.ceil(csvParseResult.entries[csvParseResult.entries.length - 1].end)}s
+              </div>
+              <div className="input-group" style={{ gap: 4 }}>
+                <label style={{ fontSize: 11, color: "var(--text-dim)", letterSpacing: 1 }}>OVERLAY TITLE</label>
+                <input
+                  type="text"
+                  value={csvMatchTitle}
+                  placeholder="e.g. U14 Girls League"
+                  onChange={function(e) { setCsvMatchTitle(e.target.value); }}
+                />
+                <span className="hint">Shown left of Set # in the overlay. Leave blank to omit.</span>
               </div>
               <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
                 <span style={{ fontSize: 11, color: "var(--text-dim)", letterSpacing: 1 }}>POSITION:</span>


### PR DESCRIPTION
## Summary
- Bug fix: encoder backpressure to prevent iOS VideoToolbox memory explosion
- Feature: LocalStorage autosave with restore dialog on page reload
- Feature: Pre-flight CSV safety download before MP4 encoding
- Feature: MP4 error recovery modal with fallback options
- Feature: CSV Import screen — generate overlay MP4 from exported CSV
- UI: Header renamed, export reorder (CSV first), position toggle

## Fixes
- Fixed CSS en-dash bug (all new classes used – instead of --)
- Restored matchTitle, generateASS, generateChromaScript, generateReadme, renderOverlayFrame from v2.0
- Fixed header overlapping iOS status bar (safe-area-inset-top)
- CSV export now includes SetsA, SetsB, MatchTitle columns
- CSV import now shows overlay title input and set scores in MP4
