### PR TITLE
docs: add analytics section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ To deploy your own:
 2. Go to **Settings → Pages → Source**: select "GitHub Actions"
 3. Push to `main` — the site deploys automatically
 
+## Analytics
+
+ScoreLayer Volley uses two privacy-first, cookieless analytics tiers. No consent banner is required — no cookies, no fingerprinting, no personal data collected.
+
+| Tier | Tool | Purpose |
+|---|---|---|
+| Pageviews & traffic | Cloudflare Web Analytics | Visits, referrers (Instagram), devices |
+| In-app events | Matomo (self-hosted, cookieless) | Feature adoption, export usage, match completion |
+
+**Tracked events:** `Match.Start`, `Match.Complete`, `Match.EndEarly`, `Highlight.Mark`, `Export.SRT/FCPXML/ASS/CSV/ChromaKit/Chapters/HlSRT`, `Export.MP4Start`, `Export.MP4Success`
+
 ## Tech Stack
 
 Single `index.html` file — React 18 (CDN), no build step, no backend.


### PR DESCRIPTION
Adds an Analytics section to the README documenting the two cookieless tracking tiers added in v2.7 (Cloudflare Web Analytics + Matomo), the privacy approach, and the full list of tracked events.

https://claude.ai/code/session_015fmHeuaQ4T1pGkns2VQkNu