### PR TITLE
Fix syncTimestamp null checks to use explicit comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@ function msToChapterTime(ms) {
 }
 
 function buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, setNumberOffset) {
-  if (!syncTimestamp) return [];
+  if (syncTimestamp == null) return [];
   var chapters = [];
 
   // Collect set-boundary chapters: first point of each set
@@ -616,7 +616,7 @@ function validateYouTubeChapters(chapters) {
 
 // --- Highlights-only SRT export ---
 function generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, setNumberOffset) {
-  if (!syncTimestamp || pointLog.length === 0) return "";
+  if (syncTimestamp == null || pointLog.length === 0) return "";
   var lines = [];
   var idx = 1;
   for (var i = 0; i < pointLog.length; i++) {


### PR DESCRIPTION
## Summary
Updated null/falsy checks for `syncTimestamp` parameter to use explicit null comparison (`== null`) instead of implicit truthiness checks (`!syncTimestamp`). This ensures the functions behave correctly when `syncTimestamp` is `0`, which is a valid timestamp value.

## Key Changes
- **buildYouTubeChapterList()**: Changed `if (!syncTimestamp)` to `if (syncTimestamp == null)` to properly handle `0` as a valid timestamp
- **generateHighlightsSRT()**: Changed `if (!syncTimestamp ||` to `if (syncTimestamp == null ||` for consistency and correctness

## Implementation Details
The original falsy check would incorrectly treat `syncTimestamp = 0` as an invalid/missing value and return early, even though `0` is a legitimate timestamp (representing the start of a video). The explicit null comparison allows `0` to pass through while still catching `null` and `undefined` values.

https://claude.ai/code/session_01VQqz25swN1wRYyjM5TFHCn