### PR TITLE
fix(v3): surface Live Share errors so failures are visible (#24)

### DIFF
--- a/index-v3.html
+++ b/index-v3.html
@@ -251,9 +251,26 @@ var PARENT_HIGHLIGHT_MAX_LEN = 140;
 var PARENT_HIGHLIGHT_THROTTLE_MS = 15000;
 var FIREBASE_READY = false;
 var firebaseAuthPromise = null;
+var firebaseLastError = null;
 
 function isFirebaseConfigured() {
   return !!(FIREBASE_CONFIG && FIREBASE_CONFIG.databaseURL && FIREBASE_CONFIG.apiKey && FIREBASE_CONFIG.projectId);
+}
+
+function describeFirebaseError(err) {
+  if (!err) return null;
+  var code = err.code || "";
+  if (code === "auth/admin-restricted-operation" || code === "auth/operation-not-allowed") {
+    return "Anonymous sign-in is disabled. In the Firebase Console open Authentication ▸ Sign-in method and enable Anonymous, then try again.";
+  }
+  if (code === "PERMISSION_DENIED" || code === "permission-denied") {
+    return "Database write rejected. Paste firebase-rules.json into Realtime Database ▸ Rules and click Publish, then try again.";
+  }
+  if (code === "auth/network-request-failed") {
+    return "Network error reaching Firebase. Check your connection and try again.";
+  }
+  if (code) return "Firebase error: " + code;
+  return err.message ? "Firebase error: " + err.message : "Firebase error.";
 }
 
 function initFirebase() {
@@ -266,15 +283,21 @@ function initFirebase() {
     if (!firebase.apps.length) firebase.initializeApp(FIREBASE_CONFIG);
     firebaseAuthPromise = firebase.auth().signInAnonymously().then(function(cred) {
       FIREBASE_READY = true;
+      firebaseLastError = null;
       return cred && cred.user ? cred.user.uid : null;
     }).catch(function(err) {
       console.warn("Firebase anonymous sign-in failed:", err);
       FIREBASE_READY = false;
+      firebaseLastError = err;
+      // Don't cache the failed promise — let the user retry after fixing config.
+      firebaseAuthPromise = null;
       return null;
     });
   } catch (err) {
     console.warn("Firebase init failed:", err);
-    firebaseAuthPromise = Promise.resolve(null);
+    firebaseLastError = err;
+    firebaseAuthPromise = null;
+    return Promise.resolve(null);
   }
   return firebaseAuthPromise;
 }
@@ -2130,6 +2153,7 @@ var sync = (function() {
       return matchId;
     }).catch(function(err) {
       console.warn("sync.createMatch failed:", err);
+      firebaseLastError = err;
       return null;
     });
   }
@@ -2389,9 +2413,14 @@ function ShareModalView(props) {
             <div className="share-hint">
               Generate a link parents in the stands can open to follow the score and submit highlight notes. The video timestamps stay aligned with your sync.
             </div>
+            {props.liveError && (
+              <div className="parent-status err" style={{ marginTop: 12 }}>{props.liveError}</div>
+            )}
             <div className="share-actions" style={{ marginTop: 16 }}>
-              <button className="btn btn-secondary" style={{ flex: 1 }} onClick={props.onClose}>Cancel</button>
-              <button className="btn btn-primary" style={{ flex: 1 }} onClick={function() { props.onStart(); }}>Start sharing</button>
+              <button className="btn btn-secondary" style={{ flex: 1 }} disabled={props.sharePending} onClick={props.onClose}>Cancel</button>
+              <button className="btn btn-primary" style={{ flex: 1 }} disabled={props.sharePending} onClick={function() { props.onStart(); }}>
+                {props.sharePending ? "Starting…" : "Start sharing"}
+              </button>
             </div>
           </>
         ) : (
@@ -2458,6 +2487,7 @@ function VolleyballTracker() {
   // Live Share state
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [liveError, setLiveError] = useState(null);
+  const [sharePending, setSharePending] = useState(false);
   const [parentSubmitStatus, setParentSubmitStatus] = useState(null); // { msg, isError }
   const lastParentSubmitRef = useRef(0);
 
@@ -2706,12 +2736,19 @@ function VolleyballTracker() {
       return;
     }
     setLiveError(null);
-    initFirebase().then(function() {
+    setSharePending(true);
+    initFirebase().then(function(uid) {
+      if (!uid) {
+        setSharePending(false);
+        setLiveError(describeFirebaseError(firebaseLastError) || "Could not sign in to Firebase. Check your network and try again.");
+        return;
+      }
       // Use the most recent state captured via setState's updater so the meta seeds correctly.
       setState(function(s) {
         sync.createMatch(s).then(function(matchId) {
+          setSharePending(false);
           if (!matchId) {
-            setLiveError("Could not start share. Check your network and try again.");
+            setLiveError(describeFirebaseError(firebaseLastError) || "Could not start share. Check your network and try again.");
             return;
           }
           setState(function(s2) { return { ...s2, role: "scorekeeper", isShared: true, matchId: matchId }; });
@@ -3142,7 +3179,7 @@ function VolleyballTracker() {
                 <button
                   className="btn btn-small"
                   style={{ background: "rgba(34,197,94,0.15)", color: "var(--success)", marginLeft: 6 }}
-                  onClick={function() { setShareModalOpen(true); }}
+                  onClick={function() { setLiveError(null); setShareModalOpen(true); }}
                 >
                   ● Live
                 </button>
@@ -3150,7 +3187,7 @@ function VolleyballTracker() {
                 <button
                   className="btn btn-small"
                   style={{ marginLeft: 6 }}
-                  onClick={function() { setShareModalOpen(true); }}
+                  onClick={function() { setLiveError(null); setShareModalOpen(true); }}
                 >
                   Share live
                 </button>
@@ -3483,7 +3520,9 @@ function VolleyballTracker() {
       {shareModalOpen && (
         <ShareModalView
           state={state}
-          onClose={function() { setShareModalOpen(false); }}
+          liveError={liveError}
+          sharePending={sharePending}
+          onClose={function() { setShareModalOpen(false); setLiveError(null); }}
           onStart={handleStartShare}
           onStop={handleStopShare}
         />


### PR DESCRIPTION
Fixes #24.

## Summary

Pressing **Start sharing** silently failed when Anonymous Auth wasn't enabled or the RTDB rules weren't deployed: the error was set on `state.liveError` but `ShareModalView` never rendered it, and the failed auth promise was cached so retries returned the same `null`. The user saw no QR/link and no explanation.

## Changes

- Add a "Starting…" pending state and disable both modal buttons while the request is in flight.
- Render `liveError` inside `ShareModalView` (it was only shown on the spectator screen).
- Map common Firebase error codes to actionable messages pointing at the exact console step to fix:
  - `auth/admin-restricted-operation` / `auth/operation-not-allowed` → "Anonymous sign-in is disabled. In the Firebase Console open Authentication ▸ Sign-in method and enable Anonymous…"
  - `PERMISSION_DENIED` → "Database write rejected. Paste firebase-rules.json into Realtime Database ▸ Rules and click Publish…"
  - `auth/network-request-failed` → network hint.
- Drop the cached `firebaseAuthPromise` on failure so the user can retry after fixing console settings without reloading.
- Clear `liveError` when reopening the modal so stale errors don't reappear.

## Test plan

- [ ] With Anonymous Auth still disabled, click **Share live → Start sharing**: the modal shows the auth message instead of doing nothing.
- [ ] Enable Anonymous Auth in Firebase Console, retry without reloading: button works and the QR/link appear.
- [ ] With rules still on the default deny, the next click surfaces the rules message.
- [ ] After publishing `firebase-rules.json`, retry: share completes successfully.
- [ ] Solo mode (no `?m=` URL) is unchanged.

https://claude.ai/code/session_01JjhkjYNFjjJikGkV5EmE4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjhkjYNFjjJikGkV5EmE4S)_