### PR TITLE
fix(v3): allow scorekeeper points write during atomic createMatch

### DIFF
--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -28,7 +28,7 @@
           "$other":         { ".validate": false }
         },
         "points": {
-          ".write": "auth != null && root.child('matches').child($matchId).child('meta/scorekeeperUid').val() === auth.uid",
+          ".write": "auth != null && (root.child('matches').child($matchId).child('meta/scorekeeperUid').val() === auth.uid || newData.parent().child('meta/scorekeeperUid').val() === auth.uid)",
           "$pushId": {
             ".validate": "newData.hasChildren(['team', 'pointsA', 'pointsB', 'setNum', 'timestamp'])"
           }


### PR DESCRIPTION
Follow-up to #25 / fixes #24.

## Summary

The improved error message from #25 told us the database write itself was being rejected. Root cause: the `points/.write` rule only looked at `root.child('meta/scorekeeperUid')`, which is the **pre-write** snapshot. `sync.createMatch` does a single atomic multi-path update that writes `meta` and backfills any already-scored points in the same transaction — so when a user pressed **Share live** after the match had already started, the points write was evaluated against a tree where `meta` didn't yet exist. `root` returned `null`, the rule failed, and the entire atomic update was rejected with `PERMISSION_DENIED`.

## Change

`points/.write` now passes if **either** the existing meta `scorekeeperUid` matches the caller (incremental writes after match creation) **or** the post-write meta `scorekeeperUid` matches (atomic `createMatch` with point backfill). The latter is read via `newData.parent().child('meta/scorekeeperUid').val()`.

```diff
- ".write": "auth != null && root.child('matches').child($matchId).child('meta/scorekeeperUid').val() === auth.uid"
+ ".write": "auth != null && (root.child('matches').child($matchId).child('meta/scorekeeperUid').val() === auth.uid || newData.parent().child('meta/scorekeeperUid').val() === auth.uid)"
```

## Action required after merge

The Firebase Console doesn't auto-pick-up changes from the repo — **re-paste `firebase-rules.json` into Realtime Database ▸ Rules and click Publish.**

## Test plan

- [ ] Score a few points in solo mode, then click **Share live → Start sharing**: modal proceeds and shows the QR/link (no rejection).
- [ ] Score additional points after sharing: each point appends to RTDB without errors (incremental writes still work).
- [ ] Spectator URL receives the backfilled points and live updates.

https://claude.ai/code/session_01JjhkjYNFjjJikGkV5EmE4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjhkjYNFjjJikGkV5EmE4S)_