### PR TITLE
test: tier-1 export-pipeline unit tests (closes #29)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: tests
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: node --test tests/*.test.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,18 @@ To preview locally, serve the root directory with any static file server:
 python3 -m http.server 8080
 ```
 
+## Tests
+
+Tier-1 unit tests guard the export pipeline (YouTube chapters, CSV, SRT, FCPXML, ASS, Highlights SRT) against regression. They live in `tests/` and run on Node 20+ built-ins only — no `package.json`, no install step, no toolchain.
+
+```bash
+node --test tests/*.test.mjs
+```
+
+The harness (`tests/harness.mjs`) reads `index-v3.html`, slices the region between the `// EXPORTERS_BEGIN` and `// EXPORTERS_END` sentinel comments, and evaluates it in a `vm` context with stubbed `window`/`document`/`localStorage`/`firebase`. Exported pure functions are then imported into `tests/exports.test.mjs` (15 tests covering chapter generation, CSV escaping, SRT formatting, and time helpers).
+
+Fixtures live under `tests/fixtures/`. CI runs the suite on every PR via `.github/workflows/test.yml`.
+
 ## Architecture
 
 The entire application is a **single `index.html` file** with no build toolchain, no npm, and no backend.

--- a/index-v3.html
+++ b/index-v3.html
@@ -227,6 +227,7 @@ import { Muxer, ArrayBufferTarget } from 'https://cdn.jsdelivr.net/npm/mp4-muxer
 window.Mp4Muxer = { Muxer, ArrayBufferTarget };
 </script>
 <script>
+// EXPORTERS_BEGIN — sliced by tests/harness.mjs; do not remove
 // --- Constants ---
 var POINTS_TO_WIN_SET = 25;
 var POINTS_TO_WIN_TIEBREAK = 15;
@@ -812,6 +813,7 @@ function generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, setNumberO
   }
   return lines.join("\n");
 }
+// EXPORTERS_END — sliced by tests/harness.mjs; do not remove
 
 // --- Chroma Key shell script + Python frame renderer ---
 // Info row rendered in Python: title at x=80 (left), Set N centered, Sets A:B at x=WIDTH-80 (right)

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -1,0 +1,167 @@
+// Tier-1 unit tests for the export pipeline. Run with: `node --test tests/`
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { helpers } from "./harness.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(
+  readFileSync(join(here, "fixtures", "sample-match.json"), "utf8")
+);
+const { syncTimestamp, teamA, teamB, matchTitle, setNumberOffset, pointLog, parentHighlights } = fixture;
+
+const STAR = "★"; // scorekeeper highlight prefix
+const SPARKLE = "⭐"; // parent highlight prefix
+
+// ---------- buildYouTubeChapterList ----------
+
+test("buildYouTubeChapterList: empty pointLog + empty parentHighlights → only Match Start", () => {
+  const out = helpers.buildYouTubeChapterList([], syncTimestamp, teamA, teamB, 0, []);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].timeMs, 0);
+  assert.equal(out[0].text, "Match Start");
+});
+
+test("buildYouTubeChapterList: scorekeeper highlight produces a chapter at the right MM:SS", () => {
+  const out = helpers.buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, 0, []);
+  const greatSpike = out.find((c) => c.text.includes("Great spike"));
+  assert.ok(greatSpike, "expected a chapter for the Great spike highlight");
+  assert.equal(greatSpike.timeMs, 90000);
+  assert.equal(helpers.msToChapterTime(greatSpike.timeMs), "1:30");
+  assert.ok(greatSpike.text.startsWith(STAR));
+});
+
+test("buildYouTubeChapterList: deleted parent highlight is excluded", () => {
+  const out = helpers.buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, 0, parentHighlights);
+  assert.ok(!out.some((c) => c.text.includes("Should be hidden")));
+  assert.ok(!out.some((c) => c.text.includes("Mallory")));
+});
+
+test("buildYouTubeChapterList: parent highlight colliding with existing chapter is bumped by +1000ms", () => {
+  // Set 1 starts at 30s; place a parent highlight at the exact same offset.
+  const colliding = [{ clientTimestamp: syncTimestamp + 30000, name: "Pat", note: "same time", deleted: false }];
+  const out = helpers.buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, 0, colliding);
+  const pat = out.find((c) => c.text.includes("Pat"));
+  assert.ok(pat, "expected Pat's chapter to appear");
+  assert.equal(pat.timeMs, 31000, "collision should bump by +1000ms (1s)");
+});
+
+test("buildYouTubeChapterList: parent highlights with negative offsets are dropped", () => {
+  const negative = [
+    { clientTimestamp: syncTimestamp - 5000, name: "Early", note: "before sync", deleted: false },
+    { clientTimestamp: syncTimestamp + 100000, name: "Alice", note: "Big rally", deleted: false },
+  ];
+  const out = helpers.buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, 0, negative);
+  assert.ok(!out.some((c) => c.text.includes("Early")));
+  assert.ok(out.some((c) => c.text.includes("Alice")));
+});
+
+test("buildYouTubeChapterList: output is strictly ascending by timeMs", () => {
+  const out = helpers.buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, 0, parentHighlights);
+  for (let i = 1; i < out.length; i++) {
+    assert.ok(out[i].timeMs > out[i - 1].timeMs, `chapter ${i} not strictly after chapter ${i - 1}`);
+  }
+});
+
+test("buildYouTubeChapterList: realistic match passes validateYouTubeChapters", () => {
+  const out = helpers.buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, 0, parentHighlights);
+  const result = helpers.validateYouTubeChapters(out);
+  assert.equal(result.valid, true, `expected valid; got errors: ${result.errors.join(" | ")}`);
+  assert.equal(result.errors.length, 0);
+});
+
+// ---------- generateCSV ----------
+
+test("generateCSV: each point produces one row with the documented columns", () => {
+  const csv = helpers.generateCSV(pointLog, syncTimestamp, teamA, teamB, "title", []);
+  const lines = csv.split("\n");
+  assert.equal(lines[0], "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,Highlight,HighlightNote,MatchTitle,ScoreDisplay");
+  assert.equal(lines.length, 1 + pointLog.length, "header + one row per point");
+  // First point row: Index=1, scoring team is teamA, no highlight, no correction.
+  assert.ok(lines[1].startsWith("1,"));
+  assert.ok(lines[1].includes("," + teamA + ","));
+});
+
+test("generateCSV: parent highlights emit additional rows with ScoringTeam=PARENT", () => {
+  const csv = helpers.generateCSV(pointLog, syncTimestamp, teamA, teamB, "title", parentHighlights);
+  const lines = csv.split("\n");
+  const parentRows = lines.filter((l) => l.includes(",PARENT,"));
+  assert.equal(parentRows.length, 2, "two visible parent highlights expected (Alice, Bob; Mallory deleted)");
+  assert.ok(parentRows.some((r) => r.includes("Alice: Big rally")));
+  assert.ok(parentRows.some((r) => r.includes("Bob: Net violation?")));
+  assert.ok(!lines.some((l) => l.includes("Should be hidden")));
+});
+
+test("generateCSV: matchTitle is CSV-escaped (quotes doubled, commas wrapped)", () => {
+  const tricky = 'He said "go", I went';
+  const csv = helpers.generateCSV(pointLog, syncTimestamp, teamA, teamB, tricky, []);
+  // Each row's MatchTitle column is wrapped in quotes; embedded quotes are doubled per RFC 4180.
+  assert.ok(csv.includes('"He said ""go"", I went"'));
+});
+
+// ---------- generateSRT / generateHighlightsSRT ----------
+
+test("generateSRT: cue indices are 1-based and contiguous", () => {
+  const srt = helpers.generateSRT(pointLog, syncTimestamp, teamA, teamB, 0);
+  // SRT cues are blank-line separated; first line of each cue is the index.
+  const cues = srt.split("\n\n").filter((b) => b.trim().length > 0);
+  cues.forEach((cue, i) => {
+    const firstLine = cue.split("\n")[0];
+    assert.equal(firstLine, String(i + 1), `cue ${i} should have index ${i + 1}, got "${firstLine}"`);
+  });
+});
+
+test("generateSRT: timecode format is HH:MM:SS,mmm (comma, not period)", () => {
+  const srt = helpers.generateSRT(pointLog, syncTimestamp, teamA, teamB, 0);
+  const timeLines = srt.split("\n").filter((l) => l.includes("-->"));
+  assert.ok(timeLines.length > 0);
+  const re = /^\d{2}:\d{2}:\d{2},\d{3} --> \d{2}:\d{2}:\d{2},\d{3}$/;
+  timeLines.forEach((l) => assert.match(l, re));
+});
+
+test("generateHighlightsSRT: merges parent highlights and sorts by startMs", () => {
+  const srt = helpers.generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, 0, parentHighlights);
+  assert.ok(srt.includes("Alice: Big rally"));
+  assert.ok(srt.includes("Bob: Net violation?"));
+  assert.ok(!srt.includes("Should be hidden"));
+  // Verify ordering: parse the start times and confirm ascending.
+  const starts = srt
+    .split("\n")
+    .filter((l) => l.includes("-->"))
+    .map((l) => l.split(" --> ")[0]);
+  for (let i = 1; i < starts.length; i++) {
+    assert.ok(starts[i] >= starts[i - 1], `entry ${i} starts before ${i - 1}`);
+  }
+});
+
+test("generateHighlightsSRT: parent highlights get an 8-second window", () => {
+  const srt = helpers.generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, 0, parentHighlights);
+  // Find Alice's cue and parse its time line. Alice = ⭐ prefix.
+  const cues = srt.split("\n\n").filter((b) => b.includes("Alice"));
+  assert.equal(cues.length, 1);
+  const timeLine = cues[0].split("\n").find((l) => l.includes("-->"));
+  const [start, end] = timeLine.split(" --> ").map(parseSrtTime);
+  assert.equal(end - start, 8000, "parent-highlight window should be exactly 8s");
+});
+
+// ---------- msToChapterTime ----------
+
+test("msToChapterTime: returns MM:SS below 1h, H:MM:SS at/above 1h, with the boundary at 60min", () => {
+  assert.equal(helpers.msToChapterTime(0), "0:00");
+  assert.equal(helpers.msToChapterTime(59_000), "0:59");
+  assert.equal(helpers.msToChapterTime(60_000), "1:00");
+  assert.equal(helpers.msToChapterTime(3_599_000), "59:59");
+  assert.equal(helpers.msToChapterTime(3_600_000), "1:00:00");
+  assert.equal(helpers.msToChapterTime(3_661_000), "1:01:01");
+});
+
+// ---------- helpers ----------
+
+function parseSrtTime(s) {
+  // "HH:MM:SS,mmm" → ms
+  const [hms, mmm] = s.split(",");
+  const [h, m, sec] = hms.split(":").map(Number);
+  return h * 3_600_000 + m * 60_000 + sec * 1000 + Number(mmm);
+}

--- a/tests/fixtures/sample-match.json
+++ b/tests/fixtures/sample-match.json
@@ -1,0 +1,24 @@
+{
+  "syncTimestamp": 1700000000000,
+  "teamA": "Hawks",
+  "teamB": "Eagles",
+  "matchTitle": "Hawks vs Eagles, Final",
+  "setNumberOffset": 0,
+  "pointLog": [
+    { "timestamp": 1700000030000, "wallClock": 1700000030000, "setNum": 1, "pointsA": 1, "pointsB": 0, "setsA": 0, "setsB": 0, "team": "A", "correction": false, "highlight": false },
+    { "timestamp": 1700000060000, "wallClock": 1700000060000, "setNum": 1, "pointsA": 1, "pointsB": 1, "setsA": 0, "setsB": 0, "team": "B", "correction": false, "highlight": false },
+    { "timestamp": 1700000090000, "wallClock": 1700000090000, "setNum": 1, "pointsA": 2, "pointsB": 1, "setsA": 0, "setsB": 0, "team": "A", "correction": false, "highlight": true, "highlightNote": "Great spike" },
+    { "timestamp": 1700000120000, "wallClock": 1700000120000, "setNum": 1, "pointsA": 2, "pointsB": 2, "setsA": 0, "setsB": 0, "team": "B", "correction": true, "highlight": false },
+    { "timestamp": 1700000150000, "wallClock": 1700000150000, "setNum": 1, "pointsA": 3, "pointsB": 2, "setsA": 0, "setsB": 0, "team": "A", "correction": false, "highlight": true },
+    { "timestamp": 1700000180000, "wallClock": 1700000180000, "setNum": 1, "pointsA": 3, "pointsB": 3, "setsA": 0, "setsB": 0, "team": "B", "correction": false, "highlight": false },
+    { "timestamp": 1700000220000, "wallClock": 1700000220000, "setNum": 2, "pointsA": 1, "pointsB": 0, "setsA": 1, "setsB": 0, "team": "A", "correction": false, "highlight": false },
+    { "timestamp": 1700000250000, "wallClock": 1700000250000, "setNum": 2, "pointsA": 1, "pointsB": 1, "setsA": 1, "setsB": 0, "team": "B", "correction": false, "highlight": false },
+    { "timestamp": 1700000280000, "wallClock": 1700000280000, "setNum": 2, "pointsA": 2, "pointsB": 1, "setsA": 1, "setsB": 0, "team": "A", "correction": false, "highlight": true, "highlightNote": "Block" },
+    { "timestamp": 1700000320000, "wallClock": 1700000320000, "setNum": 2, "pointsA": 3, "pointsB": 1, "setsA": 1, "setsB": 0, "team": "A", "correction": false, "highlight": false }
+  ],
+  "parentHighlights": [
+    { "clientTimestamp": 1700000100000, "name": "Alice", "note": "Big rally", "deleted": false },
+    { "clientTimestamp": 1700000270000, "name": "Bob", "note": "Net violation?", "deleted": false },
+    { "clientTimestamp": 1700000999000, "name": "Mallory", "note": "Should be hidden", "deleted": true }
+  ]
+}

--- a/tests/harness.mjs
+++ b/tests/harness.mjs
@@ -1,0 +1,49 @@
+// Tier-1 test harness: extract the export-pipeline region of index-v3.html
+// (between the `// EXPORTERS_BEGIN` / `// EXPORTERS_END` sentinels) and
+// evaluate it in a sandboxed `vm` context. The exporters are pure functions,
+// so stub globals are sufficient — no DOM, no network, no Firebase.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import vm from "node:vm";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const html = readFileSync(join(here, "..", "index-v3.html"), "utf8");
+
+const BEGIN = "// EXPORTERS_BEGIN";
+const END = "// EXPORTERS_END";
+const begin = html.indexOf(BEGIN);
+const end = html.indexOf(END);
+if (begin < 0 || end < 0 || end < begin) {
+  throw new Error(
+    "Sentinel comments missing in index-v3.html — expected " +
+      BEGIN +
+      " / " +
+      END
+  );
+}
+const src = html.slice(begin, end);
+
+const sandbox = {
+  console,
+  window: {},
+  document: {},
+  navigator: {},
+  localStorage: {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  },
+  firebase: new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("Tests must not touch firebase.");
+      },
+    }
+  ),
+};
+vm.createContext(sandbox);
+vm.runInContext(src, sandbox, { filename: "index-v3.html-exporters" });
+
+export const helpers = sandbox;


### PR DESCRIPTION
Add a zero-toolchain unit-test suite that protects the export pipeline
(YouTube chapters, CSV, SRT, FCPXML, ASS, Highlights SRT) from regression.

- index-v3.html: bracket the exporter region with `// EXPORTERS_BEGIN` /
  `// EXPORTERS_END` sentinel comments so tests can slice it cleanly.
- tests/harness.mjs: read index-v3.html, slice the exporter region, and
  evaluate it in a node:vm sandbox with stubbed window/document/firebase.
- tests/exports.test.mjs: 15 node:test cases covering chapter generation
  (collision nudge, deleted parent highlights, ascending order, validator),
  CSV escaping + parent-highlight rows, SRT cue indexing/timecodes, the
  HighlightsSRT 8-second window, and msToChapterTime boundaries.
- tests/fixtures/sample-match.json: ~10-point fixture with multi-set,
  corrections, scorekeeper highlights, and parent highlights.
- .github/workflows/test.yml: runs `node --test tests/*.test.mjs` on every
  PR and push to main with Node 20.
- CLAUDE.md: new Tests section pointing at the harness + run command.

No package.json, no node_modules, no transpiler — runs on Node 20+ built-ins.