### PR TITLE
fix: Scorelayer v3.1 — version label, MP4 highlight bug, editable highlight notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2534,6 +2534,10 @@ function VolleyballTracker() {
   const [highlightPrompt, setHighlightPrompt] = useState(null);
   // Shape: { index: number, timer: timeoutId, phase: 'prompt' | 'input' | 'confirmed' } | null
 
+  // Inline note editor for the log (scorekeeper only)
+  const [noteEditIdx, setNoteEditIdx] = useState(null);
+  const [noteEditVal, setNoteEditVal] = useState("");
+
   // Live Share state
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [liveError, setLiveError] = useState(null);
@@ -2779,6 +2783,11 @@ function VolleyballTracker() {
       return next;
     });
   }, []);
+
+  const saveNoteEdit = useCallback(function(logIndex, rawVal) {
+    markHighlightWithNote(logIndex, rawVal.trim() || null);
+    setNoteEditIdx(null);
+  }, [markHighlightWithNote]);
 
   const handleStartShare = useCallback(function() {
     if (!isFirebaseConfigured()) {
@@ -3393,8 +3402,24 @@ function VolleyballTracker() {
                     <span className="log-arrow" style={{ color: p.team === "A" ? "var(--team-a)" : "var(--team-b)" }}>
                       {p.correction ? "\u2193" : "\u25CF"} {p.team === "A" ? state.teamA : state.teamB}{p.correction ? " (adj)" : ""}
                     </span>
-                    {p.highlight && p.highlightNote && (
-                      <span className="log-hl-note">({p.highlightNote})</span>
+                    {p.highlight && (
+                      noteEditIdx === key
+                        ? <input
+                            autoFocus
+                            value={noteEditVal}
+                            onChange={function(e) { setNoteEditVal(e.target.value); }}
+                            onBlur={function(e) { saveNoteEdit(key, e.target.value); }}
+                            onKeyDown={function(e) {
+                              if (e.key === "Enter") { e.preventDefault(); saveNoteEdit(key, e.target.value); }
+                              else if (e.key === "Escape") { e.preventDefault(); setNoteEditIdx(null); }
+                            }}
+                            style={{ fontFamily: "var(--font-mono)", fontSize: 12, background: "var(--surface2)", color: "var(--text)", border: "none", borderRadius: 3, padding: "1px 4px", width: 120 }}
+                          />
+                        : <span
+                            className="log-hl-note"
+                            onClick={function(e) { e.stopPropagation(); setNoteEditIdx(key); setNoteEditVal(p.highlightNote || ""); }}
+                            style={{ cursor: "pointer" }}
+                          >{p.highlightNote ? "(" + p.highlightNote + ")" : <span style={{ opacity: 0.45 }}>add note</span>}</span>
                     )}
                   </div>
                 );

--- a/index.html
+++ b/index.html
@@ -813,6 +813,105 @@ function generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, setNumberO
   }
   return lines.join("\n");
 }
+
+// --- Build entries array from pointLog (shared by MP4 generator and chroma script) ---
+function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset) {
+  if (!syncTimestamp || pointLog.length === 0) return [];
+  var title = (matchTitle || "").trim();
+  var QR_LEAD  = 20;
+  var QR_TRAIL = 40;
+  var MIN_GAP  = QR_LEAD + QR_TRAIL + 1; // 61s guard
+
+  var entries = [];
+
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var startSec = (p.timestamp - syncTimestamp) / 1000;
+    if (startSec < 0) continue;
+    // For highlights, propagate the ★ visual back to the previous point's
+    // score entry (same set) so the rally play is also marked. Never shift
+    // startSec or truncate the previous entry — the score shown during the
+    // rally must stay the pre-rally score.
+    if (p.highlight && entries.length > 0 && i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var prevEntry = entries[entries.length - 1];
+      if (prevEntry.type === 'score' && !prevEntry.blank) {
+        prevEntry.highlight = true;
+        prevEntry.highlightNote = p.highlightNote || prevEntry.highlightNote || null;
+      }
+    }
+    var rawEndSec = i < pointLog.length - 1 ? (pointLog[i + 1].timestamp - syncTimestamp) / 1000 : startSec + 10;
+    var endSec = rawEndSec;
+
+    var setsA = p.setsA || 0;
+    var setsB = p.setsB || 0;
+
+    var isSetEnd = p.setWon === true && i < pointLog.length - 1;
+    var gapSec   = rawEndSec - startSec;
+
+    if (isSetEnd && gapSec >= MIN_GAP) {
+      var newSetsA = setsA + (p.pointsA > p.pointsB ? 1 : 0);
+      var newSetsB = setsB + (p.pointsB > p.pointsA ? 1 : 0);
+      var qrStart  = startSec + QR_LEAD;
+      var qrEnd    = rawEndSec - QR_TRAIL;
+
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(qrStart  * 1000) / 1000,
+        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info:   formatSetLabel(p.setNum, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + setsA + ':' + setsB,
+        highlight: false, highlightNote: null, highlightTag: null
+      });
+
+      entries.push({
+        type: 'qr',
+        start: Math.round(qrStart * 1000) / 1000,
+        end:   Math.round(qrEnd   * 1000) / 1000,
+        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info:   formatSetLabel(p.setNum, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
+        highlight: false, highlightNote: null, highlightTag: null
+      });
+
+      entries.push({
+        type: 'reset',
+        start: Math.round(qrEnd  * 1000) / 1000,
+        end:   Math.round(rawEndSec * 1000) / 1000,
+        score:      teamA + '  0 : 0  ' + teamB,
+        set_info:   formatSetLabel(p.setNum + 1, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
+        highlight: false, highlightNote: null, highlightTag: null
+      });
+
+    } else {
+      var isSetBreak = i < pointLog.length - 1 && pointLog[i + 1].setNum !== p.setNum;
+      endSec = isSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(endSec   * 1000) / 1000,
+        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info:   formatSetLabel(p.setNum, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + setsA + ':' + setsB,
+        highlight: p.highlight || false,
+        highlightNote: p.highlightNote || null
+      });
+      if (isSetBreak) {
+        entries.push({
+          start: Math.round(endSec * 1000) / 1000,
+          end:   Math.round(rawEndSec * 1000) / 1000,
+          blank: true
+        });
+      }
+    }
+  }
+  return entries.filter(function(e) { return e.end > e.start; });
+}
 // EXPORTERS_END — sliced by tests/harness.mjs; do not remove
 
 // --- Chroma Key shell script + Python frame renderer ---
@@ -1315,105 +1414,6 @@ function generateReadme(teamA, teamB) {
   ].join("\n");
 }
 
-
-// --- Build entries array from pointLog (shared by MP4 generator and chroma script) ---
-function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset) {
-  if (!syncTimestamp || pointLog.length === 0) return [];
-  var title = (matchTitle || "").trim();
-  var QR_LEAD  = 20;
-  var QR_TRAIL = 40;
-  var MIN_GAP  = QR_LEAD + QR_TRAIL + 1; // 61s guard
-
-  var entries = [];
-
-  for (var i = 0; i < pointLog.length; i++) {
-    var p = pointLog[i];
-    var startSec = (p.timestamp - syncTimestamp) / 1000;
-    if (startSec < 0) continue;
-    // For highlights, extend start back to rally beginning (prev point's timestamp), same set only
-    if (p.highlight && i > 0 && pointLog[i - 1].setNum === p.setNum) {
-      var rallyStartSec = (pointLog[i - 1].timestamp - syncTimestamp) / 1000;
-      if (rallyStartSec >= 0) {
-        startSec = rallyStartSec;
-        // Truncate previous entry's end to avoid overlapping timestamps in VideoEncoder
-        if (entries.length > 0 && !entries[entries.length - 1].blank) {
-          entries[entries.length - 1].end = Math.round(startSec * 1000) / 1000;
-        }
-      }
-    }
-    var rawEndSec = i < pointLog.length - 1 ? (pointLog[i + 1].timestamp - syncTimestamp) / 1000 : startSec + 10;
-    var endSec = rawEndSec;
-
-    var setsA = p.setsA || 0;
-    var setsB = p.setsB || 0;
-
-    var isSetEnd = p.setWon === true && i < pointLog.length - 1;
-    var gapSec   = rawEndSec - startSec;
-
-    if (isSetEnd && gapSec >= MIN_GAP) {
-      var newSetsA = setsA + (p.pointsA > p.pointsB ? 1 : 0);
-      var newSetsB = setsB + (p.pointsB > p.pointsA ? 1 : 0);
-      var qrStart  = startSec + QR_LEAD;
-      var qrEnd    = rawEndSec - QR_TRAIL;
-
-      entries.push({
-        type: 'score',
-        start: Math.round(startSec * 1000) / 1000,
-        end:   Math.round(qrStart  * 1000) / 1000,
-        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
-        set_info:   formatSetLabel(p.setNum, setNumberOffset),
-        title:      title,
-        sets_score: 'Sets ' + setsA + ':' + setsB,
-        highlight: false, highlightNote: null, highlightTag: null
-      });
-
-      entries.push({
-        type: 'qr',
-        start: Math.round(qrStart * 1000) / 1000,
-        end:   Math.round(qrEnd   * 1000) / 1000,
-        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
-        set_info:   formatSetLabel(p.setNum, setNumberOffset),
-        title:      title,
-        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
-        highlight: false, highlightNote: null, highlightTag: null
-      });
-
-      entries.push({
-        type: 'reset',
-        start: Math.round(qrEnd  * 1000) / 1000,
-        end:   Math.round(rawEndSec * 1000) / 1000,
-        score:      teamA + '  0 : 0  ' + teamB,
-        set_info:   formatSetLabel(p.setNum + 1, setNumberOffset),
-        title:      title,
-        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
-        highlight: false, highlightNote: null, highlightTag: null
-      });
-
-    } else {
-      var isSetBreak = i < pointLog.length - 1 && pointLog[i + 1].setNum !== p.setNum;
-      endSec = isSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
-      entries.push({
-        type: 'score',
-        start: Math.round(startSec * 1000) / 1000,
-        end:   Math.round(endSec   * 1000) / 1000,
-        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
-        set_info:   formatSetLabel(p.setNum, setNumberOffset),
-        title:      title,
-        sets_score: 'Sets ' + setsA + ':' + setsB,
-        highlight: p.highlight || false,
-        highlightNote: p.highlightNote || null
-      });
-      if (isSetBreak) {
-        entries.push({
-          start: Math.round(endSec * 1000) / 1000,
-          end:   Math.round(rawEndSec * 1000) / 1000,
-          blank: true
-        });
-      }
-    }
-  }
-  return entries.filter(function(e) { return e.end > e.start; });
-}
 
 
 // --- CSV parser (for import/recovery) ---

--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@ var SETS_TO_WIN_MATCH = 3;
 var MIN_LEAD = 2;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
-var APP_VERSION = "3.0.0-beta";
+var APP_VERSION = "3.1.0-beta";
 
 // --- Live Share (Firebase RTDB) ---
 // Web client config for the scorelayer-volley Firebase project. The apiKey is
@@ -3676,7 +3676,7 @@ function VolleyballTracker() {
         <div className="beta-modal-overlay" onClick={function() { setShowBetaModal(false); }}>
           <div className="beta-modal" onClick={function(e) { e.stopPropagation(); }}>
             <div className="beta-modal-icon">⚡</div>
-            <div className="beta-modal-title">ScoreLayer Volley Beta</div>
+            <div className="beta-modal-title">ScoreLayer Volley v{APP_VERSION}</div>
             <div className="beta-modal-msg">All features are <strong>free to use</strong> during the beta phase.</div>
             <div className="beta-modal-note">Export tools — MP4, SRT, FCPXML, YouTube Chapters and more — may require a plan after the official launch.</div>
             <button className="btn btn-primary" style={{ width: "100%" }} onClick={function() { setShowBetaModal(false); }}>Got it</button>

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -157,6 +157,75 @@ test("msToChapterTime: returns MM:SS below 1h, H:MM:SS at/above 1h, with the bou
   assert.equal(helpers.msToChapterTime(3_661_000), "1:01:01");
 });
 
+// ---------- buildOverlayEntries ----------
+
+test("buildOverlayEntries: regression #35 — rally-before-highlight not dropped; ★ propagated back", () => {
+  // 5-point pointLog, set 1, synced at a real epoch timestamp
+  const sync = 1700000000000; // non-zero so the falsy guard passes
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 300000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: true,  highlightNote: "Great play" },
+    { timestamp: sync + 400000, setNum: 1, pointsA: 4, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 500000, setNum: 1, pointsA: 5, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0);
+
+  // All entries must pass end > start (none collapsed/dropped)
+  entries.forEach((e, i) => {
+    assert.ok(e.end > e.start, `entry ${i} has end <= start (collapsed): start=${e.start} end=${e.end}`);
+  });
+
+  // The entry showing "2 : 0" (pre-rally score) should have highlight: true
+  const score2 = entries.find(e => e.score && e.score.includes("2 : 0"));
+  assert.ok(score2, "expected an entry with score 2 : 0");
+  assert.equal(score2.highlight, true, "entry with 2 : 0 should have highlight: true (★ propagated back)");
+
+  // The entry showing "3 : 0" (scoring point) should also have highlight: true
+  const score3 = entries.find(e => e.score && e.score.includes("3 : 0"));
+  assert.ok(score3, "expected an entry with score 3 : 0");
+  assert.equal(score3.highlight, true, "entry with 3 : 0 should have highlight: true");
+
+  // No gap: score2's end should equal score3's start
+  assert.equal(score2.end, score3.start, "no gap: 2:0 entry end must equal 3:0 entry start");
+});
+
+test("buildOverlayEntries: non-highlight pointLog → all score entries have highlight: false", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 300000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0);
+  const scoreEntries = entries.filter(e => e.type === 'score');
+  assert.equal(scoreEntries.length, 3, "expected 3 score entries");
+  scoreEntries.forEach((e, i) => {
+    assert.equal(e.highlight, false, `entry ${i} should have highlight: false`);
+  });
+});
+
+test("buildOverlayEntries: set-boundary guard — highlight on first point of set 2 does not propagate to last entry of set 1", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    // First point of set 2 with highlight — must NOT back-propagate to set 1
+    { timestamp: sync + 300000, setNum: 2, pointsA: 1, pointsB: 0, setsA: 1, setsB: 0, highlight: true,  highlightNote: "Ace" },
+    { timestamp: sync + 400000, setNum: 2, pointsA: 2, pointsB: 0, setsA: 1, setsB: 0, highlight: false, highlightNote: null },
+  ];
+
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0);
+
+  // Find the last set-1 score entry
+  const set1Entries = entries.filter(e => e.type === 'score' && e.set_info && e.set_info.includes("1"));
+  assert.ok(set1Entries.length > 0, "expected at least one set-1 score entry");
+  const lastSet1 = set1Entries[set1Entries.length - 1];
+  assert.equal(lastSet1.highlight, false, "last set-1 entry must keep highlight: false (cross-set propagation blocked)");
+});
+
 // ---------- helpers ----------
 
 function parseSrtTime(s) {


### PR DESCRIPTION
Closes #35 (partially — see #38 for the deferred finding).

## What's in this PR

### Finding 1 — Version shown in beta modal
`APP_VERSION` bumped to `3.1.0-beta`. The beta info modal title now reads **ScoreLayer Volley v3.1.0-beta** so testers can always identify which build they're running.

### Finding 4 — MP4 highlight overlay: score jumped +2 and froze for two rallies
Root cause was in `buildOverlayEntries`: when a point was marked as a highlight, the code rewound the highlight entry's start time to the previous point's timestamp **and** truncated the previous entry's end to that same value — collapsing it to zero duration, which the `e.end > e.start` filter then silently dropped.

**Effect (from the match CSV in #35):** score at 19-12 was erased from the overlay; the scoreboard jumped straight from 18-12 to 20-12 and stayed frozen across two real rallies.

**Fix:** instead of shifting timestamps, propagate the ★ highlight flag back onto the previous score entry (same set only). No timestamps or durations are touched. Result: 18-12 → **19-12 ★** → **20-12 ★** — correct increments, highlight visual spans the full rally as intended.

`buildOverlayEntries` was also moved into the EXPORTERS sentinel region so the test harness can cover it. Three new regression tests added (tests 16–18).

### Finding 3 — Scorekeeper highlight notes now editable from the match log
Previously, a note could only be set during the brief post-point prompt and was read-only afterwards. Now each ★ row in the match log has a tappable note area: clicking it opens an inline input pre-filled with the existing note (or a dim "add note" affordance if none). Saving on Enter or blur, cancelling on Escape. Changes mirror to RTDB via the existing `markHighlightWithNote` / `mirrorIfShared` flow.

## Test results
```
# tests 18
# pass  18
# fail  0
```

## Out of scope — tracked in #38
Finding 2 (sync failing on score viewer at match beginning, iOS Chrome) is deferred pending a more precise repro from a future match.