### PR TITLE
Add parent highlight tagging and quick-submit for spectators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,12 @@ Live Share is built into `index.html`. With Firebase configured, a scorekeeper c
 **RTDB tree** (`/matches/{matchId}`):
 - `meta/` — scorekeeper-only writes; teamA, teamB, syncTimestamp, scoreboard mirror, `scorekeeperUid`.
 - `points/` — append-only; same shape as the local `pointLog` entries (corrections written as new entries with `correction:true`).
-- `parentHighlights/{pushId}` — any signed-in user appends `{ name?, note, clientTimestamp, serverTimestamp, deleted }`. Scorekeeper alone can flip `deleted:true` to hide an entry.
+- `parentHighlights/{pushId}` — any signed-in user appends `{ name?, note?, tag?, quick, snapshot?, clientTimestamp, serverTimestamp, deleted }`. `tag` is one of `ace|block|kill|dig|set|error` (optional one-tap category). `quick:true` marks note-less one-tap submissions. `snapshot` freezes the live score (`pointsA, pointsB, setsA, setsB, setNum`) at submission time so the feed and the in-video overlay can show "S2 14–12" without depending on later corrections. Scorekeeper alone can flip `deleted:true` to hide an entry.
 
 **Security rules:** see `firebase-rules.json`. Paste into the Firebase console under Realtime Database ▸ Rules. They restrict `meta/` and `points/` writes to the scorekeeper UID, cap parent notes at 140 chars and names at 40 chars, and only allow the scorekeeper to set `deleted`.
 
 **Spectator URL:** `https://<host>/scorelayer-volley/?m={matchId}`. Generated client-side by the Share modal; spectators see a QR that decodes to that URL.
 
-**Parent highlights in exports:** YouTube chapters, CSV, and Highlights SRT all merge accepted (non-deleted) parent submissions in addition to the scorekeeper's `★` highlights. Parent timestamps come from the submitting client's `Date.now()` at button-press, so they align with the same `syncTimestamp` the scorekeeper used.
+**Parent highlights in exports:** YouTube chapters, CSV, Highlights SRT, **and** the in-video score overlay (`buildOverlayEntries`) all merge accepted (non-deleted) parent submissions in addition to the scorekeeper's `★` highlights. Parent timestamps come from the submitting client's `Date.now()` at button-press, so they align with the same `syncTimestamp` the scorekeeper used. For the overlay, each parent highlight whose offset falls inside an existing score entry flips that entry's `highlight=true` and appends `[tag · name · note]` to `highlightNote` (joined onto any existing scorekeeper note with ` + `).
 
 **Beta-era share links:** `index-v3.html` exists at the repo root as a thin client-side redirect to `index.html` (preserving any `?m=` query string), so QR codes and links generated during the v3.0 beta keep working.

--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -40,6 +40,17 @@
             "deleted": {
               ".write": "auth != null && root.child('matches').child($matchId).child('meta/scorekeeperUid').val() === auth.uid",
               ".validate": "newData.isBoolean()"
+            },
+            "tag":   { ".validate": "newData.val() === null || (newData.isString() && newData.val().length <= 16)" },
+            "quick": { ".validate": "newData.isBoolean()" },
+            "snapshot": {
+              ".validate": "newData.val() === null || newData.hasChildren()",
+              "pointsA": { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 99" },
+              "pointsB": { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 99" },
+              "setsA":   { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 5" },
+              "setsB":   { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 5" },
+              "setNum":  { ".validate": "newData.isNumber() && newData.val() >= 0 && newData.val() <= 99" },
+              "$other":  { ".validate": false }
             }
           }
         }

--- a/index.html
+++ b/index.html
@@ -218,6 +218,23 @@ html, body { margin: 0; padding: 0; background: #0a0e14; }
   .parent-entry-note { color: var(--text); }
   .parent-entry-deleted { color: var(--text-dim); text-decoration: line-through; }
   .parent-entry-delete-btn { background: transparent; border: none; color: var(--team-b); font-size: 10px; cursor: pointer; padding: 0 4px; letter-spacing: 1px; }
+  .parent-entry-meta-row { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .parent-entry-score { color: var(--text); font-family: var(--font-mono); font-size: 10px; padding: 1px 6px; border-radius: 999px; background: var(--surface2); letter-spacing: 0.5px; }
+  .parent-entry-tag { color: var(--warning); font-size: 10px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; }
+  .parent-form-row { display: flex; gap: 8px; }
+  .tag-chip-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+  .tag-chip { background: var(--surface2); border: 1px solid var(--surface2); color: var(--text-dim); font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; padding: 6px 10px; border-radius: 999px; cursor: pointer; font-family: var(--font-display); }
+  .tag-chip:hover { color: var(--text); }
+  .tag-chip.active { background: rgba(245,158,11,0.15); border-color: var(--warning); color: var(--warning); }
+  .spectator-prev-sets { background: var(--surface); border-radius: 10px; padding: 10px 14px; display: flex; flex-direction: column; gap: 4px; }
+  .spectator-prev-sets-title { font-size: 10px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 2px; }
+  .spectator-prev-set-row { display: flex; justify-content: space-between; align-items: baseline; font-family: var(--font-mono); font-size: 13px; }
+  .spectator-prev-set-label { color: var(--text-dim); letter-spacing: 1px; text-transform: uppercase; font-size: 11px; }
+  .spectator-prev-set-score { color: var(--text-dim); }
+  .spectator-prev-set-score .winner { color: var(--text); font-weight: 700; }
+  .spectator-prev-set-score.a-won .winner { color: var(--team-a); }
+  .spectator-prev-set-score.b-won .winner { color: var(--team-b); }
+  .spectator-prev-set-dash { margin: 0 6px; color: var(--text-dim); }
 </style>
 </head>
 <body>
@@ -235,7 +252,7 @@ var SETS_TO_WIN_MATCH = 3;
 var MIN_LEAD = 2;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
-var APP_VERSION = "3.1.0-beta";
+var APP_VERSION = "3.2.0-beta";
 
 // --- Live Share (Firebase RTDB) ---
 // Web client config for the scorelayer-volley Firebase project. The apiKey is
@@ -250,6 +267,21 @@ var FIREBASE_CONFIG = {
 };
 var PARENT_HIGHLIGHT_MAX_LEN = 140;
 var PARENT_HIGHLIGHT_THROTTLE_MS = 15000;
+// Optional one-tap categorisation for parent-submitted highlights.
+// `value` ships to RTDB as `tag`; `label` is the chip text in the spectator modal.
+var TECH_HIGHLIGHT_TAGS = [
+  { value: "ace",   label: "Ace" },
+  { value: "block", label: "Block" },
+  { value: "kill",  label: "Kill" },
+  { value: "dig",   label: "Dig" },
+  { value: "set",   label: "Set" },
+  { value: "error", label: "Error" }
+];
+var TECH_HIGHLIGHT_TAG_LABELS = (function() {
+  var m = {};
+  TECH_HIGHLIGHT_TAGS.forEach(function(t) { m[t.value] = t.label; });
+  return m;
+})();
 var FIREBASE_READY = false;
 var firebaseAuthPromise = null;
 var firebaseLastError = null;
@@ -815,7 +847,7 @@ function generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, setNumberO
 }
 
 // --- Build entries array from pointLog (shared by MP4 generator and chroma script) ---
-function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset) {
+function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset, parentHighlights) {
   if (!syncTimestamp || pointLog.length === 0) return [];
   var title = (matchTitle || "").trim();
   var QR_LEAD  = 20;
@@ -910,6 +942,37 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, 
       }
     }
   }
+
+  // Merge parent highlights: each non-deleted parent submission marks the
+  // overlay 'score' entry whose [start,end) window contains its offset, so the
+  // recorded video gets the same ★ treatment as scorekeeper-tagged stars.
+  if (parentHighlights && parentHighlights.length > 0) {
+    for (var ph = 0; ph < parentHighlights.length; ph++) {
+      var h = parentHighlights[ph];
+      if (!h || h.deleted) continue;
+      if (typeof h.clientTimestamp !== "number") continue;
+      var tSec = (h.clientTimestamp - syncTimestamp) / 1000;
+      if (tSec < 0) continue;
+      var target = null;
+      for (var k = 0; k < entries.length; k++) {
+        var e = entries[k];
+        if (e.blank || e.type !== "score") continue;
+        if (tSec >= e.start && tSec < e.end) { target = e; break; }
+      }
+      if (!target) continue;
+      var parentBlurb = [
+        h.tag ? (TECH_HIGHLIGHT_TAG_LABELS[h.tag] || h.tag) : null,
+        h.name || null,
+        h.note || null
+      ].filter(Boolean).join(" · ");
+      if (!parentBlurb) parentBlurb = "Parent highlight";
+      target.highlight = true;
+      target.highlightNote = target.highlightNote
+        ? target.highlightNote + " + " + parentBlurb
+        : parentBlurb;
+    }
+  }
+
   return entries.filter(function(e) { return e.end > e.start; });
 }
 // EXPORTERS_END — sliced by tests/harness.mjs; do not remove
@@ -2227,13 +2290,26 @@ var sync = (function() {
     return function unsubscribe() { ref.off("value", handler); };
   }
 
-  function submitParentHighlight(matchId, name, note) {
+  function submitParentHighlight(matchId, payload) {
     if (!FIREBASE_READY || !matchId) return Promise.resolve(null);
-    var trimmedNote = (note || "").trim().slice(0, PARENT_HIGHLIGHT_MAX_LEN);
-    var trimmedName = (name || "").trim().slice(0, 40);
+    payload = payload || {};
+    var trimmedNote = (payload.note || "").trim().slice(0, PARENT_HIGHLIGHT_MAX_LEN);
+    var trimmedName = (payload.name || "").trim().slice(0, 40);
+    var validTag = null;
+    if (payload.tag && TECH_HIGHLIGHT_TAG_LABELS[payload.tag]) validTag = payload.tag;
+    var snap = payload.snapshot && typeof payload.snapshot === "object" ? {
+      pointsA: payload.snapshot.pointsA | 0,
+      pointsB: payload.snapshot.pointsB | 0,
+      setsA:   payload.snapshot.setsA   | 0,
+      setsB:   payload.snapshot.setsB   | 0,
+      setNum:  payload.snapshot.setNum  | 0,
+    } : null;
     var entry = {
       name: trimmedName || null,
       note: trimmedNote || null,
+      tag: validTag,
+      quick: !trimmedNote,
+      snapshot: snap,
       clientTimestamp: Date.now(),
       serverTimestamp: firebase.database.ServerValue.TIMESTAMP,
       deleted: false,
@@ -2283,22 +2359,40 @@ function SpectatorView(props) {
   const state = props.state;
   const [name, setName] = useState(state.parentName || "");
   const [note, setNote] = useState("");
+  const [tag, setTag] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
 
   var disabledReason = props.liveError ? props.liveError : (state.matchOver ? "Match ended — highlights are closed." : null);
 
+  function makeSnapshot() {
+    return {
+      pointsA: state.pointsA || 0,
+      pointsB: state.pointsB || 0,
+      setsA:   state.setsA   || 0,
+      setsB:   state.setsB   || 0,
+      setNum:  state.currentSet || 1,
+    };
+  }
+
   function submit() {
     var trimmed = (note || "").trim();
-    if (!trimmed) return;
+    if (!trimmed && !tag) return;
     if (state.matchOver) return;
-    props.onSubmitHighlight(name, trimmed);
+    props.onSubmitHighlight({ name: name, note: trimmed, tag: tag, snapshot: makeSnapshot() });
     setNote("");
+    setTag(null);
     setModalOpen(false);
+  }
+
+  function submitQuick() {
+    if (disabledReason) return;
+    props.onSubmitHighlight({ name: name, note: "", tag: null, snapshot: makeSnapshot() });
   }
 
   function openModal() {
     if (disabledReason) return;
     setNote("");
+    setTag(null);
     setModalOpen(true);
   }
 
@@ -2315,6 +2409,13 @@ function SpectatorView(props) {
     .filter(function(h) { return !h.deleted; })
     .sort(function(a, b) { return (b.clientTimestamp || 0) - (a.clientTimestamp || 0); });
 
+  // Previous-set scores derived from the pointLog the spectator already
+  // receives — no extra meta channel needed. setWon entries mark the closing
+  // point of each finished set (skip corrections defensively).
+  var prevSets = (state.pointLog || [])
+    .filter(function(p) { return p.setWon === true && !p.correction; })
+    .map(function(p) { return { setNum: p.setNum, scoreA: p.pointsA, scoreB: p.pointsB }; });
+
   var setLabel = formatSetLabel(state.currentSet, state.setNumberOffset || 0);
   var connected = state.matchStarted || state.pointLog.length > 0;
 
@@ -2326,6 +2427,25 @@ function SpectatorView(props) {
       </div>
       {props.liveError && (
         <div className="parent-status err">{props.liveError}</div>
+      )}
+
+      {prevSets.length > 0 && (
+        <div className="spectator-prev-sets">
+          <div className="spectator-prev-sets-title">Previous sets</div>
+          {prevSets.map(function(s, i) {
+            var aWon = s.scoreA > s.scoreB;
+            return (
+              <div className="spectator-prev-set-row" key={i}>
+                <span className="spectator-prev-set-label">{formatSetLabel(s.setNum, state.setNumberOffset || 0)}</span>
+                <span className={"spectator-prev-set-score " + (aWon ? "a-won" : "b-won")}>
+                  <span className={aWon ? "winner" : ""}>{s.scoreA}</span>
+                  <span className="spectator-prev-set-dash">–</span>
+                  <span className={aWon ? "" : "winner"}>{s.scoreB}</span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
       )}
 
       <div className="spectator-scoreboard">
@@ -2352,13 +2472,25 @@ function SpectatorView(props) {
             {props.parentSubmitStatus.msg}
           </div>
         )}
-        <button
-          className="btn btn-primary"
-          disabled={!!disabledReason}
-          onClick={openModal}
-        >
-          ★ Mark highlight
-        </button>
+        <div className="parent-form-row">
+          <button
+            className="btn btn-primary"
+            disabled={!!disabledReason}
+            onClick={openModal}
+            style={{ flex: 2 }}
+          >
+            ★ Mark highlight
+          </button>
+          <button
+            className="btn btn-secondary"
+            disabled={!!disabledReason}
+            onClick={submitQuick}
+            title="One-tap highlight — records the current score with no note"
+            style={{ flex: 1 }}
+          >
+            ★ Quick
+          </button>
+        </div>
         {state.matchOver && !props.liveError && (
           <div className="share-hint" style={{ marginTop: 4 }}>Match ended. Highlights will reopen if the scorekeeper continues the match.</div>
         )}
@@ -2369,6 +2501,22 @@ function SpectatorView(props) {
           <div className="share-dialog" onClick={function(e) { e.stopPropagation(); }}>
             <div className="share-title">Mark highlight</div>
             <div className="share-hint" style={{ marginBottom: 8 }}>Tag a great moment so it shows up in the final video.</div>
+            <div>
+              <label style={{ display: "block", fontSize: 11, color: "var(--text-dim)", textTransform: "uppercase", letterSpacing: 1, marginTop: 4 }}>Category (optional)</label>
+              <div className="tag-chip-row">
+                {TECH_HIGHLIGHT_TAGS.map(function(t) {
+                  var active = tag === t.value;
+                  return (
+                    <button
+                      type="button"
+                      key={t.value}
+                      className={"tag-chip" + (active ? " active" : "")}
+                      onClick={function() { setTag(active ? null : t.value); }}
+                    >{t.label}</button>
+                  );
+                })}
+              </div>
+            </div>
             <div>
               <label style={{ display: "block", fontSize: 11, color: "var(--text-dim)", textTransform: "uppercase", letterSpacing: 1, marginTop: 8 }}>Your name (optional)</label>
               <input
@@ -2404,7 +2552,7 @@ function SpectatorView(props) {
               <button
                 className="btn btn-primary"
                 style={{ flex: 1 }}
-                disabled={!note.trim() || state.matchOver}
+                disabled={(!note.trim() && !tag) || state.matchOver}
                 onClick={submit}
               >
                 Submit
@@ -2420,13 +2568,27 @@ function SpectatorView(props) {
           {sortedHighlights.map(function(h) {
             var offsetMs = state.syncTimestamp ? (h.clientTimestamp - state.syncTimestamp) : null;
             var offsetTxt = (offsetMs != null && offsetMs >= 0) ? msToChapterTime(offsetMs) : formatClockTime(h.clientTimestamp);
+            var snap = h.snapshot;
+            var setLbl = snap ? formatSetLabel(snap.setNum, state.setNumberOffset || 0) : null;
+            var scoreTxt = snap ? (snap.pointsA + "–" + snap.pointsB) : null;
+            var tagLabel = h.tag ? (TECH_HIGHLIGHT_TAG_LABELS[h.tag] || h.tag) : null;
             return (
               <div className="parent-entry" key={h.id}>
-                <div className="parent-entry-meta">{offsetTxt}</div>
-                <div>
-                  {h.name && <span className="parent-entry-name">{h.name}: </span>}
-                  <span className="parent-entry-note">{h.note}</span>
+                <div className="parent-entry-meta parent-entry-meta-row">
+                  <span>{offsetTxt}</span>
+                  {snap && (
+                    <span className="parent-entry-score">{setLbl} {scoreTxt}</span>
+                  )}
+                  {tagLabel && (
+                    <span className="parent-entry-tag">{"★ " + tagLabel}</span>
+                  )}
                 </div>
+                {(h.name || h.note) && (
+                  <div>
+                    {h.name && <span className="parent-entry-name">{h.name}{h.note ? ": " : ""}</span>}
+                    {h.note && <span className="parent-entry-note">{h.note}</span>}
+                  </div>
+                )}
               </div>
             );
           })}
@@ -2828,8 +2990,9 @@ function VolleyballTracker() {
     setShareModalOpen(false);
   }, []);
 
-  const handleSubmitParentHighlight = useCallback(function(name, note) {
+  const handleSubmitParentHighlight = useCallback(function(payload) {
     if (!state.matchId) return;
+    payload = payload || {};
     var nowMs = Date.now();
     if (nowMs - lastParentSubmitRef.current < PARENT_HIGHLIGHT_THROTTLE_MS) {
       var waitS = Math.ceil((PARENT_HIGHLIGHT_THROTTLE_MS - (nowMs - lastParentSubmitRef.current)) / 1000);
@@ -2837,13 +3000,18 @@ function VolleyballTracker() {
       return;
     }
     lastParentSubmitRef.current = nowMs;
-    var trimmedName = (name || "").trim();
+    var trimmedName = (payload.name || "").trim();
     if (trimmedName) {
       try { localStorage.setItem(LOCALSTORAGE_PARENT_NAME_KEY, trimmedName); } catch (e) {}
     }
     setState(function(s) { return { ...s, parentName: trimmedName }; });
     setParentSubmitStatus({ msg: "Submitting…", isError: false });
-    sync.submitParentHighlight(state.matchId, trimmedName, note).then(function(key) {
+    sync.submitParentHighlight(state.matchId, {
+      name: trimmedName,
+      note: payload.note || "",
+      tag: payload.tag || null,
+      snapshot: payload.snapshot || null
+    }).then(function(key) {
       if (key) setParentSubmitStatus({ msg: "Submitted!", isError: false });
       else setParentSubmitStatus({ msg: "Submission failed. Try again.", isError: true });
       setTimeout(function() { setParentSubmitStatus(null); }, 3000);
@@ -2996,7 +3164,7 @@ function VolleyballTracker() {
   async function handleGenerateMP4() {
     if (isEncoding) return;
 
-    var entries = buildOverlayEntries(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, state.setNumberOffset || 0);
+    var entries = buildOverlayEntries(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, state.setNumberOffset || 0, state.parentHighlights || []);
     if (entries.length === 0) {
       window.alert("No sync point set or no points recorded.");
       return;
@@ -3438,22 +3606,33 @@ function VolleyballTracker() {
                 .map(function(h) {
                   var offsetMs = state.syncTimestamp ? (h.clientTimestamp - state.syncTimestamp) : null;
                   var offsetTxt = (offsetMs != null && offsetMs >= 0) ? msToChapterTime(offsetMs) : "\u2014";
+                  var snap = h.snapshot;
+                  var setLbl = snap ? formatSetLabel(snap.setNum, state.setNumberOffset || 0) : null;
+                  var tagLabel = h.tag ? (TECH_HIGHLIGHT_TAG_LABELS[h.tag] || h.tag) : null;
                   return (
                     <div className={"parent-entry" + (h.deleted ? " parent-entry-deleted" : "")} key={h.id}>
-                      <div className="parent-entry-meta">
-                        {formatClockTime(h.clientTimestamp)} \u00B7 video {offsetTxt}
+                      <div className="parent-entry-meta parent-entry-meta-row">
+                        <span>{formatClockTime(h.clientTimestamp)} \u00B7 video {offsetTxt}</span>
+                        {snap && (
+                          <span className="parent-entry-score">{setLbl} {snap.pointsA}\u2013{snap.pointsB}</span>
+                        )}
+                        {tagLabel && (
+                          <span className="parent-entry-tag">{"\u2605 " + tagLabel}</span>
+                        )}
                         {!h.deleted && (
                           <button
                             className="parent-entry-delete-btn"
                             onClick={function() { handleDeleteParentHighlight(h.id); }}
-                            style={{ float: "right" }}
+                            style={{ marginLeft: "auto" }}
                           >Delete</button>
                         )}
                       </div>
-                      <div>
-                        {h.name && <span className="parent-entry-name">{h.name}: </span>}
-                        <span className="parent-entry-note">{h.note}</span>
-                      </div>
+                      {(h.name || h.note) && (
+                        <div>
+                          {h.name && <span className="parent-entry-name">{h.name}{h.note ? ": " : ""}</span>}
+                          {h.note && <span className="parent-entry-note">{h.note}</span>}
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -207,6 +207,80 @@ test("buildOverlayEntries: non-highlight pointLog → all score entries have hig
   });
 });
 
+test("buildOverlayEntries: parent highlight marks the score entry whose window contains its timestamp", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 300000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  // Parent submits at sync + 250s — falls inside the second score entry's window.
+  const ph = [
+    { clientTimestamp: sync + 250000, name: "Alice", note: "Big rally", tag: "ace", deleted: false },
+  ];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
+  const target = entries.find(e => e.type === "score" && e.score && e.score.includes("2 : 0"));
+  assert.ok(target, "expected entry for score 2 : 0");
+  assert.equal(target.highlight, true, "parent highlight should flip the matching entry to highlight=true");
+  assert.ok(target.highlightNote && target.highlightNote.includes("Alice"), "highlightNote should include the parent name");
+  assert.ok(target.highlightNote.includes("Ace"), "highlightNote should include the tag label");
+  assert.ok(target.highlightNote.includes("Big rally"), "highlightNote should include the parent note");
+});
+
+test("buildOverlayEntries: deleted parent highlights are ignored", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const ph = [
+    { clientTimestamp: sync + 150000, name: "Mallory", note: "noise", deleted: true },
+  ];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
+  entries.filter(e => e.type === "score").forEach(e => {
+    assert.equal(e.highlight, false, "no entry should be flagged when the only parent highlight is deleted");
+  });
+});
+
+test("buildOverlayEntries: parent highlight with negative offset is ignored", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const ph = [{ clientTimestamp: sync - 5000, name: "Early", note: "pre-sync", deleted: false }];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
+  entries.filter(e => e.type === "score").forEach(e => {
+    assert.equal(e.highlight, false, "negative-offset parent highlight must not mark any entry");
+  });
+});
+
+test("buildOverlayEntries: parent highlight on a scorekeeper-starred entry appends with ' + ' rather than overwriting", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: true,  highlightNote: "Great spike" },
+    { timestamp: sync + 300000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const ph = [{ clientTimestamp: sync + 250000, name: "Alice", note: "agreed", deleted: false }];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
+  const target = entries.find(e => e.type === "score" && e.score && e.score.includes("2 : 0"));
+  assert.ok(target, "expected score 2 : 0 entry");
+  assert.ok(target.highlightNote.includes("Great spike"), "original scorekeeper note must be preserved");
+  assert.ok(target.highlightNote.includes("Alice"), "parent name must be appended");
+  assert.ok(target.highlightNote.includes(" + "), "join must use ' + ' delimiter");
+});
+
+test("buildOverlayEntries: omitting parentHighlights arg leaves output unchanged (back-compat)", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 100000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const without = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0);
+  const withEmpty = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, []);
+  assert.deepEqual(without, withEmpty, "no-arg and empty-array forms must produce identical output");
+});
+
 test("buildOverlayEntries: set-boundary guard — highlight on first point of set 2 does not propagate to last entry of set 1", () => {
   const sync = 1700000000000;
   const log = [


### PR DESCRIPTION
Closes #36

## Summary
Extends the parent highlight submission system with optional one-tap categorization (Ace, Block, Kill, Dig, Set, Error) and a quick-submit button. Parent highlights now record the match snapshot (score, set number) at submission time, enabling richer metadata in exports and spectator UI.

## Key Changes

**Spectator UI & Submission:**
- Added tag chip selector in the highlight modal with six volleyball-specific categories
- New "★ Quick" button for one-tap submission without opening the modal (records current score with no note)
- Parent highlights now require either a note OR a tag (previously required a note)
- Submission payload expanded to include `tag`, `quick` flag, and `snapshot` (pointsA, pointsB, setsA, setsB, setNum)

**Highlight Display:**
- Parent entry metadata now displays as a flex row showing: timestamp, score/set (if available), and tag label
- Conditional rendering of name/note only when present (cleaner UI for tag-only submissions)
- Scorekeeper admin panel updated with same metadata display and layout improvements

**Spectator Scoreboard:**
- Added "Previous sets" section showing completed set scores with team-color highlighting (winner in team color)
- Derived from existing pointLog `setWon` entries—no extra data channel needed

**Export Integration:**
- `buildOverlayEntries()` now accepts optional `parentHighlights` array
- Parent submissions are merged into overlay entries by matching their timestamp to the score entry's [start, end) window
- Parent metadata (tag label, name, note) appended to `highlightNote` with " + " delimiter
- Appends to existing scorekeeper highlights rather than overwriting
- Backward compatible: omitting the parameter leaves output unchanged

**Firebase & Validation:**
- Updated `submitParentHighlight()` to accept a payload object instead of separate name/note parameters
- Firebase rules extended to validate `tag` (≤16 chars), `quick` (boolean), and `snapshot` object with score/set bounds
- `TECH_HIGHLIGHT_TAGS` constant defines the tag vocabulary; `TECH_HIGHLIGHT_TAG_LABELS` map for label lookup

**Version & Tests:**
- Bumped APP_VERSION to 3.2.0-beta
- Added five new test cases covering parent highlight merging, deletion handling, negative offsets, scorekeeper note preservation, and backward compatibility

https://claude.ai/code/session_01VKA2XbMEFZ5GYWNnhyAjiM