### PR TITLE
feat(v3.4.0-beta): in-app manual + donate plumbing (#42 #43, closes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A mobile-first volleyball score tracker with timestamped point logging, multi-format export for Final Cut Pro / iMovie / YouTube, and **Live Share** so parents in the bleachers can see the live score and submit highlights straight from their phones.
 
+<!-- MANUAL_BEGIN -->
 ## Features
 
 - **Live scoring** — Tap + / − to track points with set/match auto-detection
@@ -41,6 +42,8 @@ With Firebase configured, a scorekeeper can publish the match live so spectators
 **Where parent highlights appear in exports:** YouTube chapters, CSV, Highlights SRT, **and** the in-video score overlay all merge accepted (non-deleted) parent submissions alongside the scorekeeper's own `★` highlights. Each parent highlight flips the `★` on the overlay entry whose timestamp it falls inside, and appends `[tag · name · note]` to that entry's highlight note.
 
 **Score snapshot:** the live score is frozen at submission time, so the in-video overlay and the spectator feed can show "S2 14–12" even if the scorekeeper corrects the score later.
+
+<!-- MANUAL_END -->
 
 ## Firebase Setup
 

--- a/index-v3.4.html
+++ b/index-v3.4.html
@@ -1,0 +1,4133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="theme-color" content="#0a0e14">
+<title>ScoreLayer Volley</title>
+<link rel="manifest" href="manifest.json">
+<link rel="icon" type="image/svg+xml" href="icon.svg">
+<link rel="icon" type="image/png" sizes="192x192" href="icon-192.png">
+<link rel="apple-touch-icon" href="icon-192.png">
+<link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Source+Code+Pro:wght@400;500&display=swap" rel="stylesheet">
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  _paq.push(['disableCookies']);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://quandopasso.com/Matomo/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '2']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo -->
+<script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+<script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+<!-- Firebase (compat) for Live Share. Loaded eagerly; sync helpers no-op when config missing. -->
+<script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-database-compat.js"></script>
+<!-- marked: Markdown renderer for the in-app manual. UMD build exposes window.marked. -->
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+<style>
+html, body { margin: 0; padding: 0; background: #0a0e14; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --bg: #0a0e14; --surface: #141a23; --surface2: #1c2530;
+    --accent: #ff6b2b; --accent-glow: rgba(255, 107, 43, 0.25);
+    --team-a: #3b82f6; --team-a-glow: rgba(59, 130, 246, 0.3);
+    --team-b: #ef4444; --team-b-glow: rgba(239, 68, 68, 0.3);
+    --text: #e8edf4; --text-dim: #6b7a8d;
+    --success: #22c55e; --warning: #eab308;
+    --font-display: 'Oswald', sans-serif; --font-mono: 'Source Code Pro', monospace;
+  }
+  body { background: var(--bg); color: var(--text); font-family: var(--font-display); min-height: 100dvh; -webkit-user-select: none; user-select: none; -webkit-tap-highlight-color: transparent; }
+  .app { max-width: 480px; margin: 0 auto; min-height: 100dvh; display: flex; flex-direction: column; }
+  .header { padding: calc(12px + env(safe-area-inset-top, 0px)) 16px 12px 16px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--surface2); }
+  .header h1 { font-size: 14px; font-weight: 500; letter-spacing: 3px; text-transform: uppercase; color: var(--text-dim); }
+  .header .live-dot { width: 8px; height: 8px; background: var(--accent); border-radius: 50%; animation: pulse 1.5s ease-in-out infinite; box-shadow: 0 0 8px var(--accent-glow); }
+  @keyframes pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.5; transform: scale(0.8); } }
+  .beta-badge { display: inline-flex; align-items: center; padding: 2px 8px; font-size: 9px; font-weight: 700; letter-spacing: 1.5px; color: #0a0e14; background: linear-gradient(135deg, #f59e0b, #fcd34d); border-radius: 4px; cursor: pointer; position: relative; top: -1px; vertical-align: middle; animation: betaGlow 2s ease-in-out infinite; flex-shrink: 0; }
+  @keyframes betaGlow { 0%, 100% { box-shadow: 0 0 6px rgba(245,158,11,0.6); } 50% { box-shadow: 0 0 18px rgba(245,158,11,1), 0 0 32px rgba(245,158,11,0.45); } }
+  .beta-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.78); z-index: 200; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .beta-modal { background: var(--surface); border-radius: 16px; padding: 32px 24px 24px; max-width: 320px; width: 100%; border: 1px solid rgba(245,158,11,0.4); box-shadow: 0 0 48px rgba(245,158,11,0.25), 0 8px 32px rgba(0,0,0,0.5); text-align: center; }
+  .beta-modal-icon { font-size: 36px; margin-bottom: 12px; }
+  .beta-modal-title { font-size: 16px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; margin-bottom: 16px; background: linear-gradient(135deg, #f59e0b, #fcd34d); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+  .beta-modal-msg { font-size: 14px; color: var(--text); line-height: 1.7; margin-bottom: 8px; }
+  .beta-modal-note { font-size: 12px; color: var(--text-dim); line-height: 1.6; margin-bottom: 16px; font-family: var(--font-mono); border-top: 1px solid var(--surface2); padding-top: 12px; margin-top: 12px; }
+  /* --- Donate block (shared across BetaModal, ManualModal, DonatePromptModal) --- */
+  .donate-block { display: flex; flex-direction: column; gap: 10px; margin: 12px 0 0; }
+  .donate-label { font-size: 10px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); text-align: center; }
+  .btn-donate-revolut { display: block; text-decoration: none; text-align: center; background: linear-gradient(135deg, #00b4d8, #0077b6); color: #fff; padding: 13px 20px; font-size: 13px; font-weight: 700; letter-spacing: 1.5px; border-radius: 10px; box-shadow: 0 4px 16px rgba(0,119,182,0.35); font-family: var(--font-display); text-transform: uppercase; transition: all 0.15s; }
+  .btn-donate-revolut:active { transform: scale(0.97); }
+  .donate-bizum-row { display: flex; align-items: center; gap: 8px; background: var(--surface2); border-radius: 8px; padding: 9px 12px; }
+  .donate-bizum-label { font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--text-dim); flex-shrink: 0; }
+  .donate-bizum-phone { font-family: var(--font-mono); font-size: 13px; color: var(--text); flex: 1; }
+  .donate-bizum-copy { padding: 4px 10px !important; font-size: 10px !important; flex-shrink: 0; }
+  /* --- Manual button in header --- */
+  .manual-btn { background: none; border: 1px solid var(--surface2); color: var(--text-dim); border-radius: 6px; padding: 3px 9px; font-size: 12px; font-weight: 700; cursor: pointer; font-family: var(--font-display); line-height: 1; -webkit-tap-highlight-color: transparent; }
+  .manual-btn:active { background: var(--surface2); }
+  /* --- Manual modal --- */
+  .manual-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.85); z-index: 200; display: flex; align-items: flex-end; justify-content: center; }
+  .manual-dialog { background: var(--surface); border-radius: 20px 20px 0 0; width: 100%; max-width: 480px; max-height: 90dvh; display: flex; flex-direction: column; }
+  .manual-header { display: flex; align-items: center; justify-content: space-between; padding: 18px 20px 12px; border-bottom: 1px solid var(--surface2); flex-shrink: 0; }
+  .manual-title { font-size: 13px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); }
+  .manual-body { flex: 1; overflow-y: auto; padding: 20px; -webkit-overflow-scrolling: touch; }
+  .manual-loading { color: var(--text-dim); text-align: center; padding: 32px; font-size: 13px; }
+  .manual-error { color: var(--team-b); text-align: center; padding: 16px; font-size: 13px; }
+  .manual-donate-section { margin-top: 24px; border-top: 1px solid var(--surface2); padding-top: 16px; }
+  .manual-footer { padding: 12px 20px calc(24px + env(safe-area-inset-bottom, 0px)); flex-shrink: 0; border-top: 1px solid var(--surface2); }
+  /* Markdown content inside manual */
+  .manual-content h2 { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); margin: 20px 0 8px; }
+  .manual-content h2:first-child { margin-top: 0; }
+  .manual-content p { font-size: 13px; color: var(--text); line-height: 1.7; margin: 0 0 10px; font-weight: 400; }
+  .manual-content ul, .manual-content ol { padding-left: 18px; margin: 0 0 10px; }
+  .manual-content li { font-size: 13px; color: var(--text); line-height: 1.7; font-weight: 400; }
+  .manual-content strong { font-weight: 700; color: var(--text); }
+  .manual-content code { font-family: var(--font-mono); font-size: 11px; background: var(--surface2); padding: 1px 5px; border-radius: 3px; }
+  .manual-content a { color: var(--accent); text-decoration: none; }
+  /* --- Donate prompt modal (post-export) --- */
+  .donate-prompt-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.78); z-index: 300; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .donate-prompt-dialog { background: var(--surface); border-radius: 16px; padding: 28px 20px 20px; max-width: 320px; width: 100%; border: 1px solid rgba(255,107,43,0.25); box-shadow: 0 0 40px rgba(255,107,43,0.1), 0 8px 32px rgba(0,0,0,0.5); text-align: center; }
+  .donate-prompt-icon { font-size: 32px; margin-bottom: 8px; }
+  .donate-prompt-title { font-size: 15px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; margin-bottom: 10px; color: var(--text); }
+  .donate-prompt-msg { font-size: 13px; color: var(--text-dim); line-height: 1.65; margin-bottom: 4px; font-weight: 400; }
+  .setup { flex: 1; display: flex; flex-direction: column; justify-content: center; padding: 32px 24px; gap: 28px; }
+  .setup-title { font-size: 28px; font-weight: 700; text-transform: uppercase; letter-spacing: 2px; text-align: center; background: linear-gradient(135deg, var(--accent), #ff9a5c); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+  .setup-subtitle { text-align: center; color: var(--text-dim); font-size: 13px; font-weight: 400; letter-spacing: 1px; margin-top: -16px; }
+  .input-group { display: flex; flex-direction: column; gap: 6px; }
+  .input-group label { font-size: 11px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); }
+  .input-group input { background: var(--surface); border: 1px solid var(--surface2); border-radius: 8px; padding: 14px 16px; font-family: var(--font-display); font-size: 18px; font-weight: 500; color: var(--text); outline: none; transition: border-color 0.2s; }
+  .input-group input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
+  .input-group input::placeholder { color: var(--text-dim); }
+  .format-info { background: var(--surface); border-radius: 10px; padding: 14px 16px; font-size: 13px; color: var(--text-dim); line-height: 1.5; font-weight: 400; border-left: 3px solid var(--accent); }
+  .btn { font-family: var(--font-display); font-weight: 600; letter-spacing: 2px; text-transform: uppercase; border: none; border-radius: 10px; cursor: pointer; transition: all 0.15s ease; -webkit-tap-highlight-color: transparent; }
+  .btn:active { transform: scale(0.97); }
+  .btn:disabled { opacity: 0.35; pointer-events: none; }
+  .btn-primary { background: var(--accent); color: #fff; padding: 16px 32px; font-size: 16px; box-shadow: 0 4px 20px var(--accent-glow); }
+  .btn-secondary { background: var(--surface2); color: var(--text); padding: 12px 20px; font-size: 13px; }
+  .btn-small { background: var(--surface2); color: var(--text-dim); padding: 8px 14px; font-size: 11px; }
+  .btn-danger { background: rgba(239, 68, 68, 0.15); color: var(--team-b); padding: 10px 16px; font-size: 12px; }
+  .btn-success { background: #16a34a; color: #fff; padding: 16px 32px; font-size: 16px; box-shadow: 0 4px 20px rgba(22,163,74,0.3); }
+  .match { flex: 1; display: flex; flex-direction: column; }
+  .sync-bar { padding: 10px 16px; display: flex; align-items: center; justify-content: center; gap: 10px; background: var(--surface); border-bottom: 1px solid var(--surface2); }
+  .sync-bar.sync-bar-alert { background: rgba(234, 179, 8, 0.1); border-bottom: 2px solid var(--warning); }
+  .sync-bar .sync-status { font-size: 11px; font-weight: 500; letter-spacing: 1px; text-transform: uppercase; font-family: var(--font-mono); }
+  .sync-bar .synced { color: var(--success); }
+  .sync-bar .not-synced-badge { background: var(--warning); color: #000; font-size: 11px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; font-family: var(--font-mono); padding: 4px 12px; border-radius: 5px; animation: pulse 1.5s ease-in-out infinite; }
+  .sync-dot { width: 6px; height: 6px; border-radius: 50%; }
+  .sync-dot.on { background: var(--success); box-shadow: 0 0 6px rgba(34,197,94,0.5); }
+  .sync-dot.off { background: var(--warning); }
+  .btn-sync-alert { background: var(--warning) !important; color: #000 !important; font-weight: 700 !important; padding: 10px 18px !important; font-size: 13px !important; animation: pulse 1.5s ease-in-out infinite; box-shadow: 0 2px 12px rgba(234,179,8,0.4); }
+  .sets-bar { display: flex; justify-content: center; align-items: center; gap: 16px; padding: 12px 16px; background: var(--surface); }
+  .sets-bar .set-score { font-size: 20px; font-weight: 700; letter-spacing: 1px; }
+  .sets-bar .set-label { font-size: 10px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); }
+  .sets-bar .set-divider { font-size: 18px; color: var(--text-dim); font-weight: 400; }
+  .score-area { flex: 1; display: flex; flex-direction: row; min-height: 0; }
+  .score-half { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; position: relative; padding: 12px 8px; gap: 6px; }
+  .score-half.team-a { background: linear-gradient(180deg, rgba(59,130,246,0.08) 0%, rgba(59,130,246,0.02) 100%); border-right: 1px solid var(--surface2); }
+  .score-half.team-b { background: linear-gradient(180deg, rgba(239,68,68,0.08) 0%, rgba(239,68,68,0.02) 100%); }
+  .score-half .team-name { font-size: 14px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; }
+  .score-half.team-a .team-name { color: var(--team-a); }
+  .score-half.team-b .team-name { color: var(--team-b); }
+  .score-half .points { font-size: 86px; font-weight: 700; line-height: 1; letter-spacing: -2px; min-width: 80px; text-align: center; }
+  .score-half.team-a .points { color: var(--team-a); text-shadow: 0 0 40px var(--team-a-glow); }
+  .score-half.team-b .points { color: var(--team-b); text-shadow: 0 0 40px var(--team-b-glow); }
+  .score-btn { display: flex; align-items: center; justify-content: center; border: none; border-radius: 50%; cursor: pointer; font-family: var(--font-display); font-weight: 700; -webkit-tap-highlight-color: transparent; transition: all 0.1s ease; flex-shrink: 0; }
+  .score-btn:active { transform: scale(0.9); }
+  .score-btn:disabled { opacity: 0.2; pointer-events: none; }
+  .score-btn-plus { width: 56px; height: 56px; font-size: 30px; color: #fff; }
+  .score-half.team-a .score-btn-plus { background: var(--team-a); box-shadow: 0 2px 12px var(--team-a-glow); }
+  .score-half.team-b .score-btn-plus { background: var(--team-b); box-shadow: 0 2px 12px var(--team-b-glow); }
+  .score-btn-minus { width: 40px; height: 40px; font-size: 24px; background: var(--surface2); color: var(--text-dim); border: 1px solid rgba(255,255,255,0.06); }
+  .set-point-badge { position: absolute; top: 8px; left: 50%; transform: translateX(-50%); background: var(--warning); color: #000; font-size: 10px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; padding: 3px 10px; border-radius: 4px; animation: pulse 1s ease-in-out infinite; white-space: nowrap; }
+  .match-point-badge { background: var(--accent); color: #fff; }
+  .controls { padding: 12px 16px; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; border-top: 1px solid var(--surface2); background: var(--surface); }
+  .point-log { max-height: 180px; overflow-y: auto; background: var(--bg); border-top: 1px solid var(--surface2); }
+  .log-entry { display: flex; align-items: center; padding: 6px 16px; font-family: var(--font-mono); font-size: 12px; gap: 12px; border-bottom: 1px solid var(--surface2); color: var(--text-dim); }
+  .log-entry .log-time { min-width: 70px; }
+  .log-entry .log-set { min-width: 30px; }
+  .log-entry .log-score { font-weight: 600; color: var(--text); min-width: 50px; text-align: center; }
+  .log-entry .log-team-a { color: var(--team-a); }
+  .log-entry .log-team-b { color: var(--team-b); }
+  .log-entry .log-arrow { font-size: 10px; }
+  .match-over { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 32px 24px; gap: 20px; text-align: center; overflow-y: auto; }
+  .match-over .winner { font-size: 36px; font-weight: 700; text-transform: uppercase; letter-spacing: 3px; background: linear-gradient(135deg, var(--accent), #ff9a5c); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+  .match-over .final-score { font-size: 48px; font-weight: 700; letter-spacing: 2px; }
+  .match-over .set-details { font-size: 14px; color: var(--text-dim); font-family: var(--font-mono); line-height: 1.8; }
+  .export-buttons { display: flex; flex-direction: column; gap: 10px; width: 100%; max-width: 300px; }
+  .export-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.85); display: flex; align-items: flex-end; justify-content: center; z-index: 200; }
+  .export-modal { background: var(--surface); border-radius: 20px 20px 0 0; padding: 24px 20px 36px; width: 100%; max-width: 480px; max-height: 80dvh; overflow-y: auto; display: flex; flex-direction: column; gap: 14px; }
+  .export-modal h3 { font-size: 15px; font-weight: 600; letter-spacing: 1px; text-align: center; font-family: var(--font-mono); color: var(--accent); }
+  .export-preview { background: var(--bg); border: 1px solid var(--surface2); border-radius: 8px; padding: 12px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); max-height: 200px; overflow-y: auto; white-space: pre-wrap; word-break: break-all; line-height: 1.5; -webkit-user-select: text; user-select: text; }
+  .export-actions { display: flex; flex-direction: column; gap: 8px; }
+  .copy-feedback { text-align: center; font-size: 12px; color: var(--success); font-weight: 500; letter-spacing: 1px; text-transform: uppercase; min-height: 18px; }
+  .confirm-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.7); display: flex; align-items: center; justify-content: center; z-index: 100; padding: 24px; }
+  .confirm-dialog { background: var(--surface); border-radius: 16px; padding: 24px; max-width: 320px; width: 100%; display: flex; flex-direction: column; gap: 16px; border: 1px solid var(--surface2); }
+  .confirm-dialog h3 { font-size: 18px; font-weight: 600; letter-spacing: 1px; }
+  .confirm-dialog p { font-size: 14px; color: var(--text-dim); font-weight: 400; line-height: 1.5; }
+  .confirm-actions { display: flex; gap: 10px; }
+  .confirm-actions .btn { flex: 1; }
+  .title-input-wrap { width: 100%; max-width: 300px; display: flex; flex-direction: column; gap: 6px; }
+  .title-input-wrap label { font-size: 11px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); }
+  .title-input-wrap input { background: var(--surface); border: 1px solid var(--surface2); border-radius: 8px; padding: 12px 14px; font-family: var(--font-display); font-size: 16px; font-weight: 500; color: var(--text); outline: none; transition: border-color 0.2s; -webkit-user-select: text; user-select: text; }
+  .title-input-wrap input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
+  .title-input-wrap input::placeholder { color: var(--text-dim); }
+  .title-input-wrap .hint { font-size: 11px; color: var(--text-dim); font-family: var(--font-mono); }
+  .position-toggle { display: flex; gap: 0; border-radius: 8px; overflow: hidden; border: 1px solid var(--surface2); }
+  .position-toggle button { flex: 1; padding: 8px 14px; font-family: var(--font-display); font-size: 12px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; border: none; cursor: pointer; transition: all 0.15s; background: var(--surface2); color: var(--text-dim); }
+  .position-toggle button.active { background: #16a34a; color: #fff; }
+  .progress-bar-track { width: 100%; background: var(--surface2); border-radius: 4px; overflow: hidden; height: 6px; }
+  .progress-bar-fill { height: 100%; background: #16a34a; transition: width 0.2s; }
+  .error-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.85); display: flex; align-items: center; justify-content: center; z-index: 300; padding: 24px; }
+  .error-modal { background: var(--surface); border-radius: 16px; padding: 24px; max-width: 360px; width: 100%; display: flex; flex-direction: column; gap: 16px; border: 1px solid rgba(239, 68, 68, 0.3); }
+  .error-modal h3 { font-size: 16px; font-weight: 600; letter-spacing: 1px; color: var(--team-b); text-align: center; }
+  .error-modal p { font-size: 13px; color: var(--text-dim); font-weight: 400; line-height: 1.6; }
+  .error-modal .error-detail { background: var(--bg); border: 1px solid var(--surface2); border-radius: 8px; padding: 10px 12px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); word-break: break-all; max-height: 60px; overflow-y: auto; }
+  .error-modal .error-actions { display: flex; flex-direction: column; gap: 8px; }
+  .csv-import { flex: 1; display: flex; flex-direction: column; padding: 24px; gap: 16px; overflow-y: auto; }
+  .csv-import-title { font-size: 20px; font-weight: 700; text-transform: uppercase; letter-spacing: 2px; text-align: center; color: var(--accent); }
+  .csv-import-subtitle { text-align: center; color: var(--text-dim); font-size: 12px; letter-spacing: 1px; margin-top: -8px; }
+  .csv-import textarea { background: var(--surface); border: 1px solid var(--surface2); border-radius: 8px; padding: 12px; font-family: var(--font-mono); font-size: 11px; color: var(--text); min-height: 160px; resize: vertical; outline: none; -webkit-user-select: text; user-select: text; }
+  .csv-import textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-glow); }
+  .csv-import textarea::placeholder { color: var(--text-dim); }
+  .csv-import .file-picker-row { display: flex; gap: 10px; align-items: center; }
+  .csv-import .file-picker-row input[type="file"] { display: none; }
+  .csv-import .parsed-info { background: var(--surface); border-radius: 10px; padding: 14px 16px; font-size: 13px; color: var(--text-dim); line-height: 1.5; border-left: 3px solid var(--success); }
+  .csv-import .parsed-error { border-left-color: var(--team-b); }
+  .autosave-badge { display: inline-flex; align-items: center; gap: 6px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.2); border-radius: 6px; padding: 4px 10px; font-size: 11px; font-family: var(--font-mono); color: var(--success); letter-spacing: 0.5px; }
+.highlight-pill { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 8px 18px; border-radius: 20px; background: var(--surface2); border: 1px solid var(--warning); cursor: pointer; transition: all 0.2s ease; animation: fadeIn 0.2s ease; }
+.highlight-pill.confirmed { background: rgba(234, 179, 8, 0.15); }
+.highlight-pill.expanded { gap: 6px; padding: 6px 12px; }
+.highlight-pill .hl-star { color: var(--warning); font-size: 16px; line-height: 1; }
+.highlight-pill .hl-text { font-size: 12px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--text-dim); font-family: var(--font-display); }
+.highlight-pill .hl-text.marked { color: var(--warning); }
+.highlight-pill .hl-input { background: var(--bg); border: 1px solid var(--surface2); border-radius: 6px; padding: 4px 8px; font-family: var(--font-mono); font-size: 12px; color: var(--text); outline: none; width: 120px; max-width: 120px; }
+.highlight-pill .hl-input::placeholder { color: var(--text-dim); }
+.highlight-pill .hl-input:focus { border-color: var(--warning); }
+.highlight-pill .hl-done { background: var(--warning); color: #000; border: none; border-radius: 6px; padding: 4px 10px; font-size: 11px; font-weight: 700; font-family: var(--font-display); letter-spacing: 1px; text-transform: uppercase; cursor: pointer; }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: translateY(0); } }
+.log-entry.is-highlight { background: rgba(234, 179, 8, 0.05); }
+.log-entry .log-highlight { color: var(--warning); min-width: 16px; font-size: 14px; cursor: pointer; -webkit-tap-highlight-color: transparent; }
+.log-entry .log-hl-note { color: var(--warning); font-size: 10px; font-style: italic; }
+.highlight-section-label { font-size: 11px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--warning); text-align: center; margin-bottom: 8px; }
+  /* --- v3 Live Share --- */
+  .share-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.78); z-index: 220; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .share-dialog { background: var(--surface); border-radius: 16px; padding: 24px; max-width: 360px; width: 100%; border: 1px solid var(--surface2); box-shadow: 0 8px 40px rgba(0,0,0,0.5); }
+  .share-title { font-size: 14px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); margin-bottom: 12px; text-align: center; }
+  .share-url-row { display: flex; gap: 6px; margin-top: 8px; margin-bottom: 12px; }
+  .share-url-row input { flex: 1; background: var(--surface2); border: 1px solid var(--surface2); border-radius: 6px; padding: 8px 10px; font-family: var(--font-mono); font-size: 11px; color: var(--text); }
+  .share-qr { display: flex; justify-content: center; padding: 12px; background: #fff; border-radius: 8px; margin: 8px auto; max-width: 220px; }
+  .share-qr img { width: 100%; height: auto; display: block; }
+  .share-actions { display: flex; gap: 8px; margin-top: 12px; }
+  .share-hint { font-size: 11px; color: var(--text-dim); text-align: center; line-height: 1.5; margin-top: 4px; }
+  .spectator-screen { flex: 1; display: flex; flex-direction: column; gap: 14px; padding: 16px; }
+  .spectator-banner { display: flex; align-items: center; justify-content: center; gap: 8px; background: rgba(34,197,94,0.12); border: 1px solid rgba(34,197,94,0.3); border-radius: 8px; padding: 8px 12px; font-size: 11px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--success); }
+  .spectator-banner .live-dot-bg { width: 8px; height: 8px; background: var(--success); border-radius: 50%; animation: pulse 1.5s ease-in-out infinite; }
+  .spectator-scoreboard { display: grid; grid-template-columns: 1fr auto 1fr; gap: 10px; padding: 16px; background: var(--surface); border-radius: 12px; }
+  .spectator-team { text-align: center; }
+  .spectator-team-name { font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; }
+  .spectator-team.a .spectator-team-name { color: var(--team-a); }
+  .spectator-team.b .spectator-team-name { color: var(--team-b); }
+  .spectator-points { font-size: 64px; font-weight: 700; line-height: 1; }
+  .spectator-team.a .spectator-points { color: var(--team-a); }
+  .spectator-team.b .spectator-points { color: var(--team-b); }
+  .spectator-sets { font-size: 14px; color: var(--text-dim); margin-top: 4px; font-family: var(--font-mono); }
+  .spectator-sep { font-size: 32px; color: var(--text-dim); align-self: center; }
+  .spectator-set-label { text-align: center; font-size: 11px; color: var(--text-dim); letter-spacing: 2px; text-transform: uppercase; }
+  .parent-form { background: var(--surface); border-radius: 10px; padding: 14px; display: flex; flex-direction: column; gap: 10px; }
+  .parent-form label { font-size: 10px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); }
+  .parent-form input, .parent-form textarea { background: var(--surface2); border: 1px solid var(--surface2); border-radius: 6px; padding: 10px; font-family: var(--font-display); font-size: 14px; color: var(--text); outline: none; resize: none; }
+  .parent-form input:focus, .parent-form textarea:focus { border-color: var(--accent); }
+  .parent-form .char-count { font-size: 10px; color: var(--text-dim); text-align: right; font-family: var(--font-mono); }
+  .parent-status { font-size: 12px; text-align: center; padding: 6px; border-radius: 4px; }
+  .parent-status.ok { background: rgba(34,197,94,0.1); color: var(--success); }
+  .parent-status.err { background: rgba(239,68,68,0.1); color: var(--team-b); }
+  .parent-list { background: var(--surface); border-radius: 10px; padding: 12px; max-height: 280px; overflow-y: auto; }
+  .parent-list-title { font-size: 10px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 8px; }
+  .parent-entry { padding: 8px 0; border-bottom: 1px solid var(--surface2); font-size: 13px; }
+  .parent-entry:last-child { border-bottom: none; }
+  .parent-entry-meta { font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); margin-bottom: 2px; }
+  .parent-entry-name { color: var(--accent); font-weight: 600; }
+  .parent-entry-note { color: var(--text); }
+  .parent-entry-deleted { color: var(--text-dim); text-decoration: line-through; }
+  .parent-entry-delete-btn { background: transparent; border: none; color: var(--team-b); font-size: 10px; cursor: pointer; padding: 0 4px; letter-spacing: 1px; }
+  .parent-entry-meta-row { display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+  .parent-entry-score { color: var(--text); font-family: var(--font-mono); font-size: 10px; padding: 1px 6px; border-radius: 999px; background: var(--surface2); letter-spacing: 0.5px; }
+  .parent-entry-tag { color: var(--warning); font-size: 10px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; }
+  .parent-form-row { display: flex; gap: 8px; }
+  .tag-chip-row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+  .tag-chip { background: var(--surface2); border: 1px solid var(--surface2); color: var(--text-dim); font-size: 11px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; padding: 6px 10px; border-radius: 999px; cursor: pointer; font-family: var(--font-display); }
+  .tag-chip:hover { color: var(--text); }
+  .tag-chip.active { background: rgba(245,158,11,0.15); border-color: var(--warning); color: var(--warning); }
+  .spectator-prev-sets { background: var(--surface); border-radius: 10px; padding: 10px 14px; display: flex; flex-direction: column; gap: 4px; }
+  .spectator-prev-sets-title { font-size: 10px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 2px; }
+  .spectator-prev-set-row { display: flex; justify-content: space-between; align-items: baseline; font-family: var(--font-mono); font-size: 13px; }
+  .spectator-prev-set-label { color: var(--text-dim); letter-spacing: 1px; text-transform: uppercase; font-size: 11px; }
+  .spectator-prev-set-score { color: var(--text-dim); }
+  .spectator-prev-set-score .winner { color: var(--text); font-weight: 700; }
+  .spectator-prev-set-score.a-won .winner { color: var(--team-a); }
+  .spectator-prev-set-score.b-won .winner { color: var(--team-b); }
+  .spectator-prev-set-dash { margin: 0 6px; color: var(--text-dim); }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script type="module">
+import { Muxer, ArrayBufferTarget } from 'https://cdn.jsdelivr.net/npm/mp4-muxer@5.1.3/build/mp4-muxer.mjs';
+window.Mp4Muxer = { Muxer, ArrayBufferTarget };
+</script>
+<script>
+// EXPORTERS_BEGIN — sliced by tests/harness.mjs; do not remove
+// --- Constants ---
+var POINTS_TO_WIN_SET = 25;
+var POINTS_TO_WIN_TIEBREAK = 15;
+var SETS_TO_WIN_MATCH = 3;
+var MIN_LEAD = 2;
+var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
+var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
+var APP_VERSION = "3.4.0-beta";
+// --- Donate channels (placeholders — fill real values before launch) ---
+var DONATE_URL = "https://revolut.me/your-tag";
+var BIZUM_PHONE = "+34 600 000 000";
+
+// --- Live Share (Firebase RTDB) ---
+// Web client config for the scorelayer-volley Firebase project. The apiKey is
+// a public client identifier (not a secret); RTDB security comes from
+// Anonymous Auth + the rules in firebase-rules.json.
+var FIREBASE_CONFIG = {
+  apiKey: "AIzaSyB0SYWxu2U1EkYH-0c0HSn-gEOTq0IJb9Q",
+  authDomain: "scorelayer-volley.firebaseapp.com",
+  databaseURL: "https://scorelayer-volley-default-rtdb.europe-west1.firebasedatabase.app",
+  projectId: "scorelayer-volley",
+  appId: "1:982848321994:web:657eb7ecc7a9c353b53733"
+};
+var PARENT_HIGHLIGHT_MAX_LEN = 140;
+var PARENT_HIGHLIGHT_THROTTLE_MS = 15000;
+// Optional one-tap categorisation for parent-submitted highlights.
+// `value` ships to RTDB as `tag`; `label` is the chip text in the spectator modal.
+var TECH_HIGHLIGHT_TAGS = [
+  { value: "ace",   label: "Ace" },
+  { value: "block", label: "Block" },
+  { value: "kill",  label: "Kill" },
+  { value: "dig",   label: "Dig" },
+  { value: "set",   label: "Set" },
+  { value: "error", label: "Error" }
+];
+var TECH_HIGHLIGHT_TAG_LABELS = (function() {
+  var m = {};
+  TECH_HIGHLIGHT_TAGS.forEach(function(t) { m[t.value] = t.label; });
+  return m;
+})();
+var FIREBASE_READY = false;
+var firebaseAuthPromise = null;
+var firebaseLastError = null;
+
+function isFirebaseConfigured() {
+  return !!(FIREBASE_CONFIG && FIREBASE_CONFIG.databaseURL && FIREBASE_CONFIG.apiKey && FIREBASE_CONFIG.projectId);
+}
+
+function describeFirebaseError(err) {
+  if (!err) return null;
+  var code = err.code || "";
+  if (code === "auth/admin-restricted-operation" || code === "auth/operation-not-allowed") {
+    return "Anonymous sign-in is disabled. In the Firebase Console open Authentication ▸ Sign-in method and enable Anonymous, then try again.";
+  }
+  if (code === "PERMISSION_DENIED" || code === "permission-denied") {
+    return "Database write rejected. Paste firebase-rules.json into Realtime Database ▸ Rules and click Publish, then try again.";
+  }
+  if (code === "auth/network-request-failed") {
+    return "Network error reaching Firebase. Check your connection and try again.";
+  }
+  if (code) return "Firebase error: " + code;
+  return err.message ? "Firebase error: " + err.message : "Firebase error.";
+}
+
+function initFirebase() {
+  if (firebaseAuthPromise) return firebaseAuthPromise;
+  if (!isFirebaseConfigured() || typeof firebase === "undefined") {
+    firebaseAuthPromise = Promise.resolve(null);
+    return firebaseAuthPromise;
+  }
+  try {
+    if (!firebase.apps.length) firebase.initializeApp(FIREBASE_CONFIG);
+    firebaseAuthPromise = firebase.auth().signInAnonymously().then(function(cred) {
+      FIREBASE_READY = true;
+      firebaseLastError = null;
+      return cred && cred.user ? cred.user.uid : null;
+    }).catch(function(err) {
+      console.warn("Firebase anonymous sign-in failed:", err);
+      FIREBASE_READY = false;
+      firebaseLastError = err;
+      // Don't cache the failed promise — let the user retry after fixing config.
+      firebaseAuthPromise = null;
+      return null;
+    });
+  } catch (err) {
+    console.warn("Firebase init failed:", err);
+    firebaseLastError = err;
+    firebaseAuthPromise = null;
+    return Promise.resolve(null);
+  }
+  return firebaseAuthPromise;
+}
+
+var HIGHLIGHT_PILL_MS = 8000;
+var HIGHLIGHT_PILL_EXTEND_MS = 8000;
+
+// YouTube chapter validation rules
+// Verified 2026-04-13 against https://support.google.com/youtube/answer/9884579
+var YOUTUBE_CHAPTER_RULES = {
+  FIRST_AT_ZERO: true,      // First chapter must be at 00:00
+  MIN_CHAPTERS: 3,           // Minimum 3 chapters total
+  MIN_DURATION_SEC: 10,      // Each chapter must be >=10s long
+  ASCENDING_ORDER: true,     // Strictly ascending timestamps
+  SECOND_WITHIN_SEC: 600,    // Second chapter must start within first 10 min
+};
+
+// --- QR overlay ---
+var QR_BASE64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAEsCAYAAAB5fY51AAAAAklEQVR4AewaftIAABFGSURBVO3BUY4st5YEwXCi979lH/0NcEABVGWq+lIvzEhi/jBqbgDklJoJyKRmB8gJNTtAJjUTkEnNE0BOqfmTAPlNaiYgT6g5BeRPslJVdYmVqqpLrFRVXWKlquoSK1VVl/jJ31DzDUCeADKpeQLIpGZScwrINwDZUfM2ICfUTECeAHJKzQkgk5odIJOaJ4BMQE6pmYC8Tc03AJlWqqousVJVdYmVqqpLrFRVXeIn/wCQJ9Q8AeQEkEnNKTUngOyo+RSQHTVvAzKpmYDsqJmAvA3IpGYCsgNkUvOEmhNAdtS8DchvAfKEmhMrVVWXWKmqusRKVdUlVqqqLvGTy6mZgExAdtRMQE6o2QHyKTWngDyhZgIyqXkCyBNqvkHNKSBPAHmbmgnIf8lKVdUlVqqqLrFSVXWJlaqqS6xUVV3iJxdR81vUnFLzKSCn1JwCMgGZ1ExAbqBmB8gE5Ak1TwA5oab+30pV1SVWqqousVJVdYmVqqpL/OQfUPOnAXJCzRNAJjU7QCY1E5DfpOYJNZ8CsgNkUvM2NSeA7ACZ1JxSMwGZgExqdoBMar5BzTesVFVdYqWq6hIrVVWXWKmqusRP/gaQPw2QSc0E5BSQSc0E5BvU7AA5AWRHzQRkUvMEkEnNKTUTkEnNBGRHzQRkUnNKzQRkUrMDZFIzAXkbkEnNKSC/ZaWq6hIrVVWXWKmqusRKVdUl8C+pVwF5m5oTQE6pOQFkR82ngDyh5hSQSc0E5G1qdoBMaiYgk5r/VStVVZdYqaq6xEpV1SVWqqousVJVdYmfPATklJoJyCk1E5BJzQTklJpvUPMEkEnNDpATQE4B+ZMA2VEzAZnUPAHklJoJyKRmArKj5k8C5JSaEytVVZdYqaq6xEpV1SVWqqouQRKzoWYCMqnZATKpOQHkW9RMQE6o2QEyqZmATGp2gExqJiCn1JwAsqNmAnJCzRNATqn5FJA/jZodIN+g5gSQJ9RMK1VVl1ipqrrESlXVJVaqqi6Bf8mXAHlCzQRkUvMEkEnNE0DepmYCsqNmAjKpOQVkUnMCyI6aTwE5pWYCckrNBOSUmhNAJjU7QCY1E5BJzRNAnlAzAZlWqqousVJVdYmVqqpLrFRVXeIHyI6aE0B21Exq/kuA7Kj5lJodICfUPAHkG9Q8AeSUmhNqnlAzAdkB8icBsqNmAjKpOQVkAjKpmVaqqi6xUlV1iZWqqkusVFVdYqWq6hI/+RtAJjVvA3JKzaRmAjKpOaXmCSCTmv8aNW8DckLNBGQHyKTmbUAmNTtAJjUTkFNqJiCTmlNAJjUTkFNqJiAnVqqqLrFSVXWJlaqqS6xUVV3iR80OkCeATGomNaeATGomNaeAnFBzSs0E5BuAPKFmArID5BvUTEAmNTtAPgVkR82kZgLypwEyqXlCzQTkbStVVZdYqaq6xEpV1SVWqqou8QPk36BmAvKEmhNAJjU7aiYgE5BvUHMKyCk1E5An1ExAJjVPAHlCzQTkN6n5BjUngDwB5Ak1J1aqqi6xUlV1iZWqqkusVFVdgiTmX6BmAjKpmYCcUjMBmdTsAPmUmh0gn1LzBJAdNROQJ9ScADKp2QEyqTkBZEfNCSCTmn8DkBNqJiD/C9RMK1VVl1ipqrrESlXVJVaqqi6xUlV1iR81O0AmNROQHSCTmgnIKTWfArKj5hvUTECeAHIKyAk1E5BTQP40QCY1TwCZ1ExAdtRMQCYgp9S8Dcik5gSQHTUngEwrVVWXWKmqusRKVdUlVqqqLvEDZEfNBGRSswNkAjKpuQGQbwBySs0pIN+gZgJySs0JIE8A+U1ATqiZgOwAmdRMQE6peRuQT61UVV1iparqEitVVZdYqaq6BEnMJdRMQL5BzSkgk5oJyKRmB8gTaiYgk5pTQCY13wBkUrMD5ISatwHZUTMBeULNp4DsqJmAnFDzBJBpparqEitVVZdYqaq6xEpV1SV+8g+omYDsqPktap4AcgM1E5AdIJOaJ9RMQL5BzSk1E5AngJxQswPkhJpTQE6omdS8DcjbVqqqLrFSVXWJlaqqS6xUVV1iparqEviXbAB5Qs0JIJOaHSCTmhNA3qZmB8gJNaeAfIOaCci3qJmAPKFmAnJCzSkgp9S8DcgJNaeATGomIJOat61UVV1iparqEitVVZdYqaq6xE/+hpoJyKRmB8gJNROQ/1VATqk5BWRSMwGZ1OwAuQGQSc0EZALybwAyqZmAvA3IE0B+y0pV1SVWqqousVJVdYmVqqpL/ORvAHlCzQRkAvI2IJOaHSAn1ExATqk5oeYJIG8DckrNBOQUkEnNBORtak4BmdRMQHbUTEAmNROQU2omIJOaJ4CcAvKplaqqS6xUVV1iparqEitVVZdYqaq6BEnMhpoTQHbUfArIb1IzAZnUnAIyqZmAPKFmB8jb1ExATqjZATKpeRuQE2pOAZnUnAJyQs0OkLepeRuQSc2JlaqqS6xUVV1iparqEitVVZcgiTmk5gkg36BmArKjZgLyW9ScAvKEmgnIE2reBmRS8wSQE2qeALKj5gSQSc3bgJxSMwE5pWYCcmKlquoSK1VVl1ipqrrESlXVJX7yLwEyqXkCyKTmt6jZATKpmYCcAnJCzSkgT6iZgExqJiA7aiY1E5An1JwAsqNmAvINQHbUTEBOqNkBMgGZ1ExATqk5sVJVdYmVqqpLrFRVXWKlquoS+JdsAJnUnALyDWpOAHmbmlNAnlDzBJATaiYgv0nN24A8oeYJIJOaE0B21ExA/jRqPrVSVXWJlaqqS6xUVV1iparqEitVVZcgiTmkZgJySs0TQD6lZgfICTVvAzKp+TcAeZuaTwH5TWomIE+o+QYgp9RMQCY1TwD5hpWqqkusVFVdYqWq6hIrVVWX+FHzm4BMat4GZEfNCSBvU/M2IE+omYCcAjKpeULNBGRSswNkAjKpmYDsqDkBZEfNCSCTmlNAngAyqXlCzQkg00pV1SVWqqousVJVdYmVqqpL/OQfAPI2NU+omYCcAjKpmdRMQN4GZEfNBGRSswPkG9R8g5oJyBNAJjU7QCY1k5odIJOaE0BOqZmAnFLzKTU7QCY1J1aqqi6xUlV1iZWqqkusVFVd4if/gJoJyCkgfxo1E5A/DZBJzQTklJoJyCkgb1MzAZnU/CY1T6iZgJxQ8zYgbwPytpWqqkusVFVdYqWq6hIrVVWXWKmqusRP/gaQSc2k5jcBuYGaCcgTQE6pOaHmG4CcUvOEmgnIpOYUkCfUnFAzAXlCzQRkR80EZFIzAXlCzbRSVXWJlaqqS6xUVV1iparqEj9AvgXIE2omNROQSc3b1OwA+QY1E5C3ATmlZgIyqdkBckLNb1IzAZnUnFJzQs0OkEnNBOQJNROQSc0TQKaVqqpLrFRVXWKlquoSK1VVl8C/5EuATGpOAZnUTEBOqfkUkB01J4BManaAnFBzCsgJNTtAPqXmFJATanaA/Jeo2QEyqZmATGp2gLxNzQTkxEpV1SVWqqousVJVdYmVqqpL/ADZUXMCyBNATqmZgJxQswPkU2q+Rc0E5BSQE2qeUHMCyCk1E5AJyI6aE0BOqZmAnFIzAXkbkEnNBOSUmgnIpOZtK1VVl1ipqrrESlXVJVaqqi6xUlV1CZKYQ2omIDtqJiCTmgnIt6g5AeQ3qTkB5FvUfArIE2reBmRS828AMqmZgDyhZgIyqdkBckLNKSAn1EwrVVWXWKmqusRKVdUlVqqqLoF/ySEgk5odIJOaCcgpNSeAfIOaJ4B8i5oJyG9R8wSQSc3bgOyomYCcUjMBOaHmFJATam6wUlV1iZWqqkusVFVdYqWq6hI/+RtATgB5Qs0E5BSQE2pOAZnUnAIyqflNQCY1E5BTaiYgk5oJyCk1k5qbAZnUnACyo+aEmieATGomIDtqJiCTmmmlquoSK1VVl1ipqrrESlXVJUhi/gVqTgCZ1LwNyCk1E5BJzRNAJjWngExqdoD8FjVvAzKp2QEyqZmAnFIzAZnUPAHklJoTQCY1TwA5peZTK1VVl1ipqrrESlXVJVaqqi6xUlV1iR81O0AmNROQU0AmNROQHTVvU/M2IJOat6mZgOyomYB8A5BTak6omYC8Tc0OkEnNKSCTmhNqTgGZ1ExAdtRMQCY1E5AdIJ9aqaq6xEpV1SVWqqousVJVdYmf/A01TwA5AeQJIJOaU0BOqJmA7Kj5FJBTat6m5hSQT6k5BeQb1HyLmgnIpOY3ATkB5JSaT61UVV1iparqEitVVZdYqaq6BEnMhpongExqTgA5peYbgExqTgF5Qs0EZFLzLUAmNU8AmdRMQE6pOQHkbWp2gExqJiCTmh0gn1JzCsgJNTtAPrVSVXWJlaqqS6xUVV1iparqEitVVZcgiTmk5hSQT6n5FiCTmhNAdtScAPKEmieATGreBuSUmgnIE2pOADmlZgJySs2ngDyh5hSQE2pOAZnUTECmlaqqS6xUVV1iparqEitVVZf4yd9QMwGZ1DyhZgLyLWpOAJnU7ACZ1DyhZgIyqTml5gSQHTVvAzKpeQLICTVvU/M2NTtA3qbmU0DetlJVdYmVqqpLrFRVXWKlquoS+JdsAPnTqDkB5JSaCcikZgLyv0zNBOQJNROQE2p2gExqJiCTmlNA3qZmArKj5huATGq+YaWq6hIrVVWXWKmqusRKVdUlSGI21JwAsqNmAjKpmYCcUjMBOaXmBJBJzQ6QE2omIDtqngByQs0EZEfNBGRSMwE5peYEkN+k5hSQSc0TQCY1E5BTak4AOaXmUytVVZdYqaq6xEpV1SVWqqousVJVdYmf/ANAJjVPAJnU7AD5lJon1JxSMwH5TWo+pWYHyNvUvE3NBGRS8wSQU2omIJOaCcgTaiYgO0AmNSfU7AD51EpV1SVWqqousVJVdYmVqqpL/ORvADkB5JSaE0C+BcgJNaeAvA3Ib1FzSs0EZFKzA+Qb1LxNzSkgJ4BMat6mZgfIBGRS8w0rVVWXWKmqusRKVdUlVqqqLoF/yS8C8oSaJ4BMak4A2VFzAyC3UjMBeULNBGRHzQTklJoTQP5r1ExATqxUVV1iparqEitVVZdYqaq6BP4llwByQs3bgDyhZgJySs0E5Ak1J4DsqPkUkB01J4BManaAfIOaCcgpNROQU2omICfUPAFkUrMDZFJzYqWq6hIrVVWXWKmqusRKVdUlVqqqLvED5E+j5m1AdtRMQCY1p4CcUDMB2QHyNiBvAzKpOQXkU0B21ExAJjWngJxQ8zY13wJkUnMCyNtWqqousVJVdYmVqqpLrFRVXYIkZkPNNwCZ1JwC8g1qJiA7at4G5Ak1J4CcUvMpIDtqJiCTmieAnFDzbwAyqTkB5G1qngDyNjXTSlXVJVaqqi6xUlV1iZWqqkv85B8A8oSaJ4B8Ss0OkEnNCTVPAJnU7KiZgExqdoBMap4A8g1qTgDZUTOpmYB8i5oJyAk1TwCZgHyLmgnIiZWqqkusVFVdYqWq6hIrVVWX+Mnl1JwAsqPmU0CeUDMBeQLIjpoJyAk1O0BOqJmA7AA5oeYUkEnNpGYCsqNmAjKp2QEyqZmATEBOqfkGNaeATGpOrFRVXWKlquoSK1VVl1ipqrrESlXVJX5yETUTkEnNE0AmNZOaJ4BMak4BmdTsADmh5pSaE0CeUHNCzQ6QCcikZlKzA+QEkB01E5ATan6TmgnIpOYUkBMrVVWXWKmqusRKVdUlVqqqLvGTf0DNn0bNCTU7QCY1E5BJzduAfIuatwGZ1ExAdtRMQCY1E5AdNROQCcik5pSaU0AmNSeAvE3NDpATaiYgb1upqrrESlXVJVaqqi6xUlV1CZKYP4yaJ4BMap4A8g1qdoCcULMD5ISaCciOmhNAJjU7QCY1fxogb1PzNiCTmgnIE2omIDtqPrVSVXWJlaqqS6xUVV1iparqEv8HcPmq7WF7orEAAAAASUVORK5CYII=';
+var _qrImageCache = null;
+
+async function getQRImageBitmap() {
+  if (_qrImageCache) return _qrImageCache;
+  var img = new Image();
+  img.src = QR_BASE64;
+  await new Promise(function(res, rej) {
+    img.onload = res;
+    img.onerror = rej;
+  });
+  _qrImageCache = await createImageBitmap(img);
+  return _qrImageCache;
+}
+
+// --- Analytics ---
+function trackEvent(category, action, name, value) {
+  if (window._paq) {
+    var args = ['trackEvent', category, action];
+    if (name !== undefined) args.push(name);
+    if (value !== undefined) args.push(value);
+    window._paq.push(args);
+  }
+}
+
+// --- Helpers ---
+function formatSRTTime(ms) {
+  if (ms < 0) ms = 0;
+  var h = Math.floor(ms / 3600000);
+  var m = Math.floor((ms % 3600000) / 60000);
+  var s = Math.floor((ms % 60000) / 1000);
+  var mil = ms % 1000;
+  return String(h).padStart(2, "0") + ":" + String(m).padStart(2, "0") + ":" + String(s).padStart(2, "0") + "," + String(mil).padStart(3, "0");
+}
+
+function formatClockTime(ts) {
+  var d = new Date(ts);
+  return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function formatSetLabel(setNum, offset) {
+  var n = setNum + (offset || 0);
+  if (n === 0) return "Warm-up";
+  return "Set " + n;
+}
+
+function isTiebreakSet(setsA, setsB) {
+  return setsA === SETS_TO_WIN_MATCH - 1 && setsB === SETS_TO_WIN_MATCH - 1;
+}
+
+function getTargetPoints(setsA, setsB) {
+  return isTiebreakSet(setsA, setsB) ? POINTS_TO_WIN_TIEBREAK : POINTS_TO_WIN_SET;
+}
+
+function isSetWon(pA, pB, target) {
+  return (pA >= target || pB >= target) && Math.abs(pA - pB) >= MIN_LEAD;
+}
+
+function createInitialState() {
+  return {
+    teamA: "Home",
+    teamB: "Away",
+    matchTitle: "",
+    setsA: 0,
+    setsB: 0,
+    pointsA: 0,
+    pointsB: 0,
+    setHistory: [],
+    pointLog: [],
+    matchStarted: false,
+    matchOver: false,
+    syncTimestamp: null,
+    currentSet: 1,
+    extraSetMode: false,
+    setNumberOffset: 0,
+    // v3 Live Share (additive; v2.9.4 ignores these)
+    role: "solo",          // "solo" | "scorekeeper" | "spectator"
+    isShared: false,
+    matchId: null,
+    parentName: "",
+    parentHighlights: [],
+  };
+}
+
+var SCREEN = { SETUP: "setup", MATCH: "match", CSV_IMPORT: "csv_import", SPECTATOR: "spectator" };
+
+// --- LocalStorage autosave ---
+function autosaveState(state) {
+  try {
+    localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify({
+      teamA: state.teamA, teamB: state.teamB, matchTitle: state.matchTitle,
+      setsA: state.setsA, setsB: state.setsB,
+      pointsA: state.pointsA, pointsB: state.pointsB,
+      setHistory: state.setHistory, pointLog: state.pointLog,
+      matchStarted: state.matchStarted, matchOver: state.matchOver,
+      syncTimestamp: state.syncTimestamp, currentSet: state.currentSet,
+      extraSetMode: state.extraSetMode || false,
+      setNumberOffset: state.setNumberOffset || 0,
+      // v3: matchId persists so a scorekeeper resuming after refresh can re-join their share.
+      // role/isShared are derived at load time (URL or explicit user action), not from cache.
+      matchId: state.matchId || null,
+      savedAt: Date.now()
+    }));
+  } catch (e) { /* localStorage full or unavailable */ }
+}
+
+function loadAutosave() {
+  try {
+    var raw = localStorage.getItem(LOCALSTORAGE_KEY);
+    if (!raw) return null;
+    var data = JSON.parse(raw);
+    if (!data.matchStarted) return null;
+    return data;
+  } catch (e) { return null; }
+}
+
+function clearAutosave() {
+  try { localStorage.removeItem(LOCALSTORAGE_KEY); } catch (e) {}
+}
+
+
+// --- Generators ---
+function generateSRT(pointLog, syncTimestamp, teamA, teamB, setNumberOffset) {
+  if (!syncTimestamp || pointLog.length === 0) return "";
+  var lines = [];
+  var idx = 1;
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var startMs = p.timestamp - syncTimestamp;
+    if (startMs < 0) continue;
+    // For highlights, extend start back to rally beginning (prev point's timestamp), same set only
+    if (p.highlight && i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var rallyStartMs = pointLog[i - 1].timestamp - syncTimestamp;
+      if (rallyStartMs >= 0) startMs = rallyStartMs;
+    }
+    // If the next point is a highlight in the same set its start will be shifted back to
+    // this point's timestamp, so cap our end there to avoid overlapping subtitle entries
+    var nextP = i < pointLog.length - 1 ? pointLog[i + 1] : null;
+    var nextHighlightSameSet = nextP && nextP.highlight && nextP.setNum === p.setNum;
+    var rawEndMs = nextHighlightSameSet
+      ? (p.timestamp - syncTimestamp)
+      : (nextP ? nextP.timestamp - syncTimestamp : startMs + 10000);
+    // Cut at midpoint when set changes so the old score clears before the new set begins
+    var isSetBreak = nextP && nextP.setNum !== p.setNum;
+    var endMs = isSetBreak ? Math.round((startMs + rawEndMs) / 2) : rawEndMs;
+    if (endMs <= startMs) continue; // skip zero-duration entries absorbed by adjacent highlight
+    lines.push(String(idx));
+    lines.push(formatSRTTime(startMs) + " --> " + formatSRTTime(endMs));
+    var hlPrefix = p.highlight ? "\u2605 " : "";
+    var hlSuffix = (p.highlight && p.highlightNote) ? " [" + p.highlightNote + "]" : "";
+    lines.push(hlPrefix + formatSetLabel(p.setNum, setNumberOffset) + " | " + teamA + " " + p.pointsA + " - " + p.pointsB + " " + teamB + hlSuffix);
+    lines.push("");
+    idx++;
+  }
+  return lines.join("\n");
+}
+
+function generateCSV(pointLog, syncTimestamp, teamA, teamB, matchTitle, parentHighlights) {
+  var header = "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,Highlight,HighlightNote,MatchTitle,ScoreDisplay";
+  var rows = pointLog.map(function(p, i) {
+    var offset = syncTimestamp ? p.timestamp - syncTimestamp : "";
+    var title = (matchTitle || "").replace(/"/g, '""');
+    var displayPrefix = p.highlight ? "\u2605 " : "";
+    return [i + 1, formatClockTime(p.wallClock), offset, p.setNum, p.pointsA, p.pointsB, p.setsA || 0, p.setsB || 0, p.team === "A" ? teamA : teamB, p.correction ? "Y" : "N", p.highlight ? "Y" : "N", '"' + ((p.highlightNote || "").replace(/"/g, '""')) + '"', '"' + title + '"', '"' + displayPrefix + teamA + " " + p.pointsA + "-" + p.pointsB + " " + teamB + '"'].join(",");
+  });
+  // Append parent-submitted highlights (Live Share). They share the same column
+  // schema; ScoringTeam=PARENT marks them, Highlight=Y, HighlightNote carries the message.
+  var startIdx = pointLog.length + 1;
+  if (parentHighlights && parentHighlights.length) {
+    var t2 = (matchTitle || "").replace(/"/g, '""');
+    parentHighlights.forEach(function(p, k) {
+      if (!p || p.deleted) return;
+      var offset = syncTimestamp ? p.clientTimestamp - syncTimestamp : "";
+      var noteWithName = (p.name ? p.name + ": " : "") + (p.note || "");
+      rows.push([startIdx + k, formatClockTime(p.clientTimestamp), offset, "", "", "", "", "", "PARENT", "N", "Y", '"' + noteWithName.replace(/"/g, '""') + '"', '"' + t2 + '"', '"\u2b50 ' + (p.name || "Anon") + '"'].join(","));
+    });
+  }
+  return [header].concat(rows).join("\n");
+}
+
+function generateFCPXML(pointLog, syncTimestamp, teamA, teamB, setNumberOffset) {
+  if (!syncTimestamp || pointLog.length === 0) return "";
+  var fps = 25;
+  function toFrac(ms) { var frames = Math.round((ms / 1000) * fps); return frames * 100 + "/" + (fps * 100) + "s"; }
+  var titles = "";
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var startMs = p.timestamp - syncTimestamp;
+    if (startMs < 0) continue;
+    // For highlights, extend start back to rally beginning (prev point's timestamp), same set only
+    if (p.highlight && i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var rallyStartMs = pointLog[i - 1].timestamp - syncTimestamp;
+      if (rallyStartMs >= 0) startMs = rallyStartMs;
+    }
+    var nextP = i < pointLog.length - 1 ? pointLog[i + 1] : null;
+    var nextHighlightSameSet = nextP && nextP.highlight && nextP.setNum === p.setNum;
+    var rawEndMs = nextHighlightSameSet
+      ? (p.timestamp - syncTimestamp)
+      : (nextP ? nextP.timestamp - syncTimestamp : startMs + 10000);
+    var isSetBreak = nextP && nextP.setNum !== p.setNum;
+    var endMs = isSetBreak ? Math.round((startMs + rawEndMs) / 2) : rawEndMs;
+    if (endMs <= startMs) continue;
+    var dur = endMs - startMs;
+    var text = formatSetLabel(p.setNum, setNumberOffset) + " | " + teamA + " " + p.pointsA + " - " + p.pointsB + " " + teamB;
+    titles += '            <title name="' + text + '" offset="' + toFrac(startMs) + '" duration="' + toFrac(dur) + '">\n';
+    titles += '              <text><text-style ref="ts1">' + text + '</text-style></text>\n';
+    titles += '            </title>\n';
+  }
+  var markers = "";
+  for (var m = 0; m < pointLog.length; m++) {
+    var pm = pointLog[m];
+    if (!pm.highlight) continue;
+    var markerMs = pm.timestamp - syncTimestamp;
+    if (markerMs < 0) continue;
+    var markerText = "\u2605 " + formatSetLabel(pm.setNum, setNumberOffset) + " | " + teamA + " " + pm.pointsA + " - " + pm.pointsB + " " + teamB;
+    if (pm.highlightNote) markerText += " [" + pm.highlightNote + "]";
+    markers += '            <marker start="' + toFrac(markerMs) + '" duration="100/' + (fps * 100) + 's" value="' + markerText.replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;") + '" />\n';
+  }
+  var totalDur = pointLog[pointLog.length - 1].timestamp - syncTimestamp + 10000;
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE fcpxml>',
+    '<fcpxml version="1.11">',
+    '  <resources>',
+    '    <format id="r1" frameDuration="100/' + (fps * 100) + 's" width="1920" height="1080"/>',
+    '  </resources>',
+    '  <library>',
+    '    <event name="Volleyball Score">',
+    '      <project name="Score Overlay">',
+    '        <sequence format="r1" tcStart="0s" tcFormat="NDF" audioLayout="stereo" audioRate="48k">',
+    '          <spine>',
+    '            <gap name="Gap" offset="0s" duration="' + toFrac(totalDur) + '" start="0s">',
+    titles + markers,
+    '            </gap>',
+    '          </spine>',
+    '        </sequence>',
+    '      </project>',
+    '    </event>',
+    '  </library>',
+    '</fcpxml>'
+  ].join("\n");
+}
+
+// --- ASS subtitle format ---
+// Info row layout: [matchTitle left] [Set N center] [Sets A:B right]
+// Uses \pos() + \an override tags for precise left/center/right placement.
+function formatASSTime(ms) {
+  if (ms < 0) ms = 0;
+  var h = Math.floor(ms / 3600000);
+  var m = Math.floor((ms % 3600000) / 60000);
+  var s = Math.floor((ms % 60000) / 1000);
+  var cs = Math.floor((ms % 1000) / 10);
+  return String(h) + ":" + String(m).padStart(2, "0") + ":" + String(s).padStart(2, "0") + "." + String(cs).padStart(2, "0");
+}
+
+function generateASS(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset) {
+  if (!syncTimestamp || pointLog.length === 0) return "";
+  var title = (matchTitle || "").trim();
+  var header = [
+    "[Script Info]",
+    "Title: Volleyball Score Overlay",
+    "ScriptType: v4.00+",
+    "PlayResX: 1920",
+    "PlayResY: 1080",
+    "WrapStyle: 0",
+    "",
+    "[V4+ Styles]",
+    "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding",
+    // Score: large, bold, bottom-center (Alignment=2)
+    "Style: Score,Arial,72,&H00FFFFFF,&H000000FF,&H00000000,&H80000000,-1,0,0,0,100,100,2,0,1,3,2,2,40,40,50,1",
+    // ScoreHL: highlight style — gold text (ASS BGR: #eae000 → &H0000E0EA)
+    "Style: ScoreHL,Arial,72,&H0000E0EA,&H000000FF,&H00000000,&H80000000,-1,0,0,0,100,100,2,0,1,3,2,2,40,40,50,1",
+    // SetInfo: same size/colour as in the original, bottom-center default but overridden with \an+\pos per dialogue
+    "Style: SetInfo,Arial,36,&H0000CCFF,&H000000FF,&H00000000,&H80000000,-1,0,0,0,100,100,1,0,1,2,1,2,40,40,50,1",
+    "",
+    "[Events]",
+    "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text"
+  ].join("\n");
+
+  var events = [];
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var startMs = p.timestamp - syncTimestamp;
+    if (startMs < 0) continue;
+    // For highlights, extend start back to rally beginning (prev point's timestamp), same set only
+    if (p.highlight && i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var rallyStartMs = pointLog[i - 1].timestamp - syncTimestamp;
+      if (rallyStartMs >= 0) startMs = rallyStartMs;
+    }
+    var nextP = i < pointLog.length - 1 ? pointLog[i + 1] : null;
+    var nextHighlightSameSet = nextP && nextP.highlight && nextP.setNum === p.setNum;
+    var rawEndMs = nextHighlightSameSet
+      ? (p.timestamp - syncTimestamp)
+      : (nextP ? nextP.timestamp - syncTimestamp : startMs + 10000);
+    var isSetBreak = nextP && nextP.setNum !== p.setNum;
+    var endMs = isSetBreak ? Math.round((startMs + rawEndMs) / 2) : rawEndMs;
+    if (endMs <= startMs) continue;
+    var startT = formatASSTime(startMs);
+    var endT = formatASSTime(endMs);
+
+    // Bottom score line - large, centered
+    var scoreText = teamA + "  " + p.pointsA + "  -  " + p.pointsB + "  " + teamB;
+    var scoreStyle = p.highlight ? "ScoreHL" : "Score";
+    events.push("Dialogue: 0," + startT + "," + endT + "," + scoreStyle + ",,0,0,0,," + scoreText);
+
+    // Info row - three positioned elements on same Y level (y=900, i.e. 130px above score baseline)
+    // \an1 = bottom-left anchor, \an2 = bottom-center, \an3 = bottom-right
+    var centerText = formatSetLabel(p.setNum, setNumberOffset);
+    var rightText = "Sets " + p.setsA + ":" + p.setsB;
+
+    if (title) {
+      events.push("Dialogue: 1," + startT + "," + endT + ",SetInfo,,0,0,0,,{\\an1\\pos(80,900)}" + title);
+    }
+    events.push("Dialogue: 1," + startT + "," + endT + ",SetInfo,,0,0,0,,{\\an2\\pos(960,900)}" + centerText);
+    events.push("Dialogue: 1," + startT + "," + endT + ",SetInfo,,0,0,0,,{\\an3\\pos(1840,900)}" + rightText);
+  }
+  return header + "\n" + events.join("\n") + "\n";
+}
+
+// --- YouTube Chapters export ---
+function msToChapterTime(ms) {
+  var totalSec = Math.floor(ms / 1000);
+  var h = Math.floor(totalSec / 3600);
+  var m = Math.floor((totalSec % 3600) / 60);
+  var s = totalSec % 60;
+  return h > 0
+    ? h + ":" + String(m).padStart(2, "0") + ":" + String(s).padStart(2, "0")
+    : m + ":" + String(s).padStart(2, "0");
+}
+
+function buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, setNumberOffset, parentHighlights) {
+  if (syncTimestamp == null) return [];
+  var chapters = [];
+
+  // Collect set-boundary chapters: first point of each set
+  var setFirstMs = {};
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var ms = p.timestamp - syncTimestamp;
+    if (ms < 0) continue;
+    if (setFirstMs[p.setNum] === undefined) setFirstMs[p.setNum] = ms;
+  }
+
+  // Determine if Set 1 starts at (or within 1s of) 00:00
+  var set1StartMs = setFirstMs[1] !== undefined ? setFirstMs[1] : null;
+  var set1AtZero = set1StartMs !== null && set1StartMs <= 1000;
+
+  // Add Match Start at 00:00 (or skip if Set 1 starts at 00:00)
+  if (!set1AtZero) {
+    chapters.push({ timeMs: 0, text: "Match Start" });
+  }
+
+  // Add one chapter per set boundary
+  var setNums = Object.keys(setFirstMs).map(Number).sort(function(a, b) { return a - b; });
+  for (var j = 0; j < setNums.length; j++) {
+    var setNum = setNums[j];
+    var setMs = setFirstMs[setNum];
+    var label = formatSetLabel(setNum, setNumberOffset) + " Start";
+    if (set1AtZero && setNum === 1) {
+      chapters.push({ timeMs: 0, text: label });
+    } else {
+      chapters.push({ timeMs: setMs, text: label });
+    }
+  }
+
+  // Add highlight chapters — skip if timestamp coincides with a set boundary
+  var setFirstMsValues = {};
+  for (var setKey in setFirstMs) { setFirstMsValues[setFirstMs[setKey]] = true; }
+  for (var k = 0; k < pointLog.length; k++) {
+    var ph = pointLog[k];
+    if (!ph.highlight) continue;
+    var offsetMs = ph.timestamp - syncTimestamp;
+    if (offsetMs < 0) continue;
+    // When a highlight is the first point of a set, it coincides with the set boundary chapter.
+    // Skip the highlight chapter to avoid duplicate timestamps that break ascending order.
+    var effectiveMs = (set1AtZero && ph.setNum === 1) ? 0 : offsetMs;
+    if (setFirstMsValues[effectiveMs]) continue;
+    var hlText = "\u2605 " + teamA + " " + ph.pointsA + "-" + ph.pointsB + " " + teamB + " (" + formatSetLabel(ph.setNum, setNumberOffset) + ")";
+    if (ph.highlightNote) hlText += " [" + ph.highlightNote + "]";
+    chapters.push({ timeMs: effectiveMs, text: hlText });
+  }
+
+  // Add parent-submitted highlights (Live Share). Bumps colliding timestamps
+  // by 1s so YouTube's strictly-ascending rule still holds.
+  if (parentHighlights && parentHighlights.length) {
+    var seenMs = {};
+    chapters.forEach(function(c) { seenMs[c.timeMs] = true; });
+    for (var pi = 0; pi < parentHighlights.length; pi++) {
+      var pp = parentHighlights[pi];
+      if (!pp || pp.deleted) continue;
+      var pms = pp.clientTimestamp - syncTimestamp;
+      if (pms < 0) continue;
+      while (seenMs[pms]) pms += 1000;
+      seenMs[pms] = true;
+      var ptxt = "\u2b50 " + (pp.name ? pp.name + ": " : "") + (pp.note || "highlight");
+      chapters.push({ timeMs: pms, text: ptxt });
+    }
+  }
+
+  // Sort chronologically
+  chapters.sort(function(a, b) { return a.timeMs - b.timeMs; });
+
+  return chapters;
+}
+
+function generateYouTubeChapters(pointLog, syncTimestamp, teamA, teamB, setNumberOffset, parentHighlights) {
+  var chapters = buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, setNumberOffset, parentHighlights);
+  if (chapters.length === 0) return "";
+  return chapters.map(function(c) {
+    return msToChapterTime(c.timeMs) + " " + c.text;
+  }).join("\n");
+}
+
+function validateYouTubeChapters(chapters) {
+  var errors = [];
+  if (chapters.length === 0) { return { valid: false, errors: ["No chapters generated."] }; }
+
+  if (YOUTUBE_CHAPTER_RULES.FIRST_AT_ZERO && chapters[0].timeMs !== 0) {
+    errors.push("First chapter must be at 00:00 (currently at " + msToChapterTime(chapters[0].timeMs) + ").");
+  }
+  if (YOUTUBE_CHAPTER_RULES.MIN_CHAPTERS && chapters.length < YOUTUBE_CHAPTER_RULES.MIN_CHAPTERS) {
+    errors.push("YouTube requires at least " + YOUTUBE_CHAPTER_RULES.MIN_CHAPTERS + " chapters (only " + chapters.length + " generated).");
+  }
+  if (YOUTUBE_CHAPTER_RULES.ASCENDING_ORDER) {
+    for (var i = 1; i < chapters.length; i++) {
+      if (chapters[i].timeMs <= chapters[i - 1].timeMs) {
+        errors.push("Chapter timestamps must be strictly ascending (duplicate or out-of-order at " + msToChapterTime(chapters[i].timeMs) + ").");
+        break;
+      }
+    }
+  }
+  if (YOUTUBE_CHAPTER_RULES.MIN_DURATION_SEC) {
+    for (var j = 0; j < chapters.length - 1; j++) {
+      var durSec = (chapters[j + 1].timeMs - chapters[j].timeMs) / 1000;
+      if (durSec < YOUTUBE_CHAPTER_RULES.MIN_DURATION_SEC) {
+        errors.push("Chapter \"" + chapters[j].text + "\" is only " + durSec.toFixed(1) + "s long (minimum " + YOUTUBE_CHAPTER_RULES.MIN_DURATION_SEC + "s required).");
+      }
+    }
+  }
+  if (YOUTUBE_CHAPTER_RULES.SECOND_WITHIN_SEC && chapters.length >= 2) {
+    var secondSec = chapters[1].timeMs / 1000;
+    if (secondSec > YOUTUBE_CHAPTER_RULES.SECOND_WITHIN_SEC) {
+      errors.push("Second chapter must start within the first 10 minutes (currently at " + msToChapterTime(chapters[1].timeMs) + ").");
+    }
+  }
+  return { valid: errors.length === 0, errors: errors };
+}
+
+// --- Highlights-only SRT export ---
+function generateHighlightsSRT(pointLog, syncTimestamp, teamA, teamB, setNumberOffset, parentHighlights) {
+  if (syncTimestamp == null || pointLog.length === 0) return "";
+  // Build a unified list of (startMs, endMs, text) entries from scorekeeper highlights
+  // and parent highlights, then sort and emit as a single SRT.
+  var entries = [];
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    if (!p.highlight) continue;
+    var startMs = p.timestamp - syncTimestamp;
+    if (startMs < 0) continue;
+    // Extend start back to rally beginning (prev point's timestamp), same set only
+    if (i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var rallyStartMs = pointLog[i - 1].timestamp - syncTimestamp;
+      if (rallyStartMs >= 0) startMs = rallyStartMs;
+    }
+    // If the next point is also a highlight in the same set, cap our end to avoid overlap
+    var nextP = i < pointLog.length - 1 ? pointLog[i + 1] : null;
+    var nextHighlightSameSet = nextP && nextP.highlight && nextP.setNum === p.setNum;
+    var endMs = nextHighlightSameSet
+      ? (p.timestamp - syncTimestamp)
+      : (nextP ? nextP.timestamp - syncTimestamp : startMs + 10000);
+    if (endMs <= startMs) continue;
+    var text = "\u2605 " + formatSetLabel(p.setNum, setNumberOffset) + " | " + teamA + " " + p.pointsA + " - " + p.pointsB + " " + teamB;
+    if (p.highlightNote) text += " [" + p.highlightNote + "]";
+    entries.push({ startMs: startMs, endMs: endMs, text: text });
+  }
+  // Parent highlights: 8s default subtitle window from clientTimestamp.
+  if (parentHighlights && parentHighlights.length) {
+    parentHighlights.forEach(function(pp) {
+      if (!pp || pp.deleted) return;
+      var s = pp.clientTimestamp - syncTimestamp;
+      if (s < 0) return;
+      var ptxt = "\u2b50 " + (pp.name ? pp.name + ": " : "") + (pp.note || "highlight");
+      entries.push({ startMs: s, endMs: s + 8000, text: ptxt });
+    });
+  }
+  entries.sort(function(a, b) { return a.startMs - b.startMs; });
+  var lines = [];
+  for (var idx = 0; idx < entries.length; idx++) {
+    var e = entries[idx];
+    lines.push(String(idx + 1));
+    lines.push(formatSRTTime(e.startMs) + " --> " + formatSRTTime(e.endMs));
+    lines.push(e.text);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// --- Build entries array from pointLog (shared by MP4 generator and chroma script) ---
+function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset, parentHighlights) {
+  if (!syncTimestamp || pointLog.length === 0) return [];
+  var title = (matchTitle || "").trim();
+  var QR_LEAD  = 20;
+  var QR_TRAIL = 40;
+  var MIN_GAP  = QR_LEAD + QR_TRAIL + 1; // 61s guard
+
+  var entries = [];
+
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var startSec = (p.timestamp - syncTimestamp) / 1000;
+    if (startSec < 0) continue;
+    // For highlights, propagate the ★ visual back to the previous point's
+    // score entry (same set) so the rally play is also marked. Never shift
+    // startSec or truncate the previous entry — the score shown during the
+    // rally must stay the pre-rally score.
+    if (p.highlight && entries.length > 0 && i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var prevEntry = entries[entries.length - 1];
+      if (prevEntry.type === 'score' && !prevEntry.blank) {
+        prevEntry.highlight = true;
+        prevEntry.highlightNote = p.highlightNote || prevEntry.highlightNote || null;
+      }
+    }
+    var rawEndSec = i < pointLog.length - 1 ? (pointLog[i + 1].timestamp - syncTimestamp) / 1000 : startSec + 10;
+    var endSec = rawEndSec;
+
+    var setsA = p.setsA || 0;
+    var setsB = p.setsB || 0;
+
+    var isSetEnd = p.setWon === true && i < pointLog.length - 1;
+    var gapSec   = rawEndSec - startSec;
+
+    if (isSetEnd && gapSec >= MIN_GAP) {
+      var newSetsA = setsA + (p.pointsA > p.pointsB ? 1 : 0);
+      var newSetsB = setsB + (p.pointsB > p.pointsA ? 1 : 0);
+      var qrStart  = startSec + QR_LEAD;
+      var qrEnd    = rawEndSec - QR_TRAIL;
+
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(qrStart  * 1000) / 1000,
+        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info:   formatSetLabel(p.setNum, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + setsA + ':' + setsB,
+        highlight: false, highlightNote: null, highlightTag: null
+      });
+
+      entries.push({
+        type: 'qr',
+        start: Math.round(qrStart * 1000) / 1000,
+        end:   Math.round(qrEnd   * 1000) / 1000,
+        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info:   formatSetLabel(p.setNum, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
+        highlight: false, highlightNote: null, highlightTag: null
+      });
+
+      entries.push({
+        type: 'reset',
+        start: Math.round(qrEnd  * 1000) / 1000,
+        end:   Math.round(rawEndSec * 1000) / 1000,
+        score:      teamA + '  0 : 0  ' + teamB,
+        set_info:   formatSetLabel(p.setNum + 1, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
+        highlight: false, highlightNote: null, highlightTag: null
+      });
+
+    } else {
+      var isSetBreak = i < pointLog.length - 1 && pointLog[i + 1].setNum !== p.setNum;
+      endSec = isSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(endSec   * 1000) / 1000,
+        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info:   formatSetLabel(p.setNum, setNumberOffset),
+        title:      title,
+        sets_score: 'Sets ' + setsA + ':' + setsB,
+        highlight: p.highlight || false,
+        highlightNote: p.highlightNote || null
+      });
+      if (isSetBreak) {
+        entries.push({
+          start: Math.round(endSec * 1000) / 1000,
+          end:   Math.round(rawEndSec * 1000) / 1000,
+          blank: true
+        });
+      }
+    }
+  }
+
+  // Merge parent highlights: each non-deleted parent submission marks the
+  // overlay 'score' entry whose [start,end) window contains its offset, so the
+  // recorded video gets the same ★ treatment as scorekeeper-tagged stars.
+  if (parentHighlights && parentHighlights.length > 0) {
+    for (var ph = 0; ph < parentHighlights.length; ph++) {
+      var h = parentHighlights[ph];
+      if (!h || h.deleted) continue;
+      if (typeof h.clientTimestamp !== "number") continue;
+      var tSec = (h.clientTimestamp - syncTimestamp) / 1000;
+      if (tSec < 0) continue;
+      var target = null;
+      for (var k = 0; k < entries.length; k++) {
+        var e = entries[k];
+        if (e.blank || e.type !== "score") continue;
+        if (tSec >= e.start && tSec < e.end) { target = e; break; }
+      }
+      if (!target) continue;
+      var parentBlurb = [
+        h.tag ? (TECH_HIGHLIGHT_TAG_LABELS[h.tag] || h.tag) : null,
+        h.name || null,
+        h.note || null
+      ].filter(Boolean).join(" · ");
+      if (!parentBlurb) parentBlurb = "Parent highlight";
+      target.highlight = true;
+      target.highlightNote = target.highlightNote
+        ? target.highlightNote + " + " + parentBlurb
+        : parentBlurb;
+    }
+  }
+
+  return entries.filter(function(e) { return e.end > e.start; });
+}
+// EXPORTERS_END — sliced by tests/harness.mjs; do not remove
+
+// --- Chroma Key shell script + Python frame renderer ---
+// Info row rendered in Python: title at x=80 (left), Set N centered, Sets A:B at x=WIDTH-80 (right)
+function generateChromaScript(pointLog, syncTimestamp, teamA, teamB, matchTitle, setNumberOffset) {
+  if (!syncTimestamp || pointLog.length === 0) return "";
+  var title = (matchTitle || "").trim();
+  var lastEntry = pointLog[pointLog.length - 1];
+  var totalSec = Math.ceil((lastEntry.timestamp - syncTimestamp + 10000) / 1000);
+  var fname = "volleyball_" + teamA + "_vs_" + teamB;
+
+  // Build JSON data for the Python script - includes title and sets_score per entry
+  var QR_LEAD_CS  = 20;
+  var QR_TRAIL_CS = 40;
+  var MIN_GAP_CS  = QR_LEAD_CS + QR_TRAIL_CS + 1;
+  var entries = [];
+  for (var i = 0; i < pointLog.length; i++) {
+    var p = pointLog[i];
+    var startSec = (p.timestamp - syncTimestamp) / 1000;
+    if (startSec < 0) continue;
+    // For highlights, extend start back to rally beginning (prev point's timestamp), same set only
+    if (p.highlight && i > 0 && pointLog[i - 1].setNum === p.setNum) {
+      var rallyStartSec = (pointLog[i - 1].timestamp - syncTimestamp) / 1000;
+      if (rallyStartSec >= 0) {
+        startSec = rallyStartSec;
+        // Truncate previous entry's end to avoid timestamp overlap
+        if (entries.length > 0 && !entries[entries.length - 1].blank) {
+          entries[entries.length - 1].end = Math.round(startSec * 1000) / 1000;
+        }
+      }
+    }
+    var rawEndSec = i < pointLog.length - 1
+      ? (pointLog[i + 1].timestamp - syncTimestamp) / 1000
+      : startSec + 10;
+
+    var csA = p.setsA || 0;
+    var csB = p.setsB || 0;
+    var isSetEnd = p.setWon === true && i < pointLog.length - 1;
+    var gapSec   = rawEndSec - startSec;
+
+    if (isSetEnd && gapSec >= MIN_GAP_CS) {
+      var newSetsA = csA + (p.pointsA > p.pointsB ? 1 : 0);
+      var newSetsB = csB + (p.pointsB > p.pointsA ? 1 : 0);
+      var qrStart  = startSec + QR_LEAD_CS;
+      var qrEnd    = rawEndSec - QR_TRAIL_CS;
+
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(qrStart  * 1000) / 1000,
+        score: teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info: formatSetLabel(p.setNum, setNumberOffset),
+        title: title,
+        sets_score: 'Sets ' + csA + ':' + csB,
+        highlight: false, highlightNote: null
+      });
+      entries.push({
+        type: 'qr',
+        start: Math.round(qrStart * 1000) / 1000,
+        end:   Math.round(qrEnd   * 1000) / 1000,
+        score: teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
+        set_info: formatSetLabel(p.setNum, setNumberOffset),
+        title: title,
+        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
+        highlight: false, highlightNote: null
+      });
+      entries.push({
+        type: 'reset',
+        start: Math.round(qrEnd     * 1000) / 1000,
+        end:   Math.round(rawEndSec * 1000) / 1000,
+        score: teamA + '  0 : 0  ' + teamB,
+        set_info: formatSetLabel(p.setNum + 1, setNumberOffset),
+        title: title,
+        sets_score: 'Sets ' + newSetsA + ':' + newSetsB,
+        highlight: false, highlightNote: null
+      });
+    } else {
+      var isSetBreak = i < pointLog.length - 1 && pointLog[i + 1].setNum !== p.setNum;
+      var endSec = isSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(endSec   * 1000) / 1000,
+        score: teamA + "  " + p.pointsA + " : " + p.pointsB + "  " + teamB,
+        set_info: formatSetLabel(p.setNum, setNumberOffset),
+        title: title,
+        sets_score: "Sets " + csA + ":" + csB,
+        highlight: p.highlight || false,
+        highlightNote: p.highlightNote || null
+      });
+      if (isSetBreak) {
+        entries.push({
+          start: Math.round(endSec * 1000) / 1000,
+          end:   Math.round(rawEndSec * 1000) / 1000,
+          blank: true
+        });
+      }
+    }
+  }
+  entries = entries.filter(function(e) { return e.end > e.start; });
+
+  var jsonData = JSON.stringify(entries);
+
+  var lines = [
+    "#!/bin/bash",
+    "# ============================================",
+    "# Volleyball Score Chroma Key Video Generator",
+    "# ============================================",
+    "# Generates a green-screen MP4 with score overlay.",
+    "#",
+    "# Uses Python + Pillow to render one PNG per score",
+    "# change (keyframe-based), then FFmpeg concat demuxer",
+    "# to assemble the final MP4. Fast: typically < 30s.",
+    "#",
+    "# PREREQUISITES (one-time):",
+    "#   brew install ffmpeg python3",
+    "#   pip3 install Pillow",
+    "#",
+    "# USAGE:",
+    "#   chmod +x generate_overlay.sh",
+    "#   ./generate_overlay.sh",
+    "# ============================================",
+    "",
+    'OUTPUT="' + fname + '_overlay.mp4"',
+    "DURATION=" + totalSec,
+    "FPS=30",
+    "WIDTH=1920",
+    "HEIGHT=1080",
+    "",
+    "# --- Check dependencies ---",
+    'if ! command -v ffmpeg &> /dev/null; then',
+    '  echo "ERROR: ffmpeg not found. Install: brew install ffmpeg"',
+    "  exit 1",
+    "fi",
+    'if ! command -v python3 &> /dev/null; then',
+    '  echo "ERROR: python3 not found. Install: brew install python3"',
+    "  exit 1",
+    "fi",
+    'python3 -c "from PIL import Image" 2>/dev/null || {',
+    '  echo "Installing Pillow..."',
+    "  pip3 install Pillow --break-system-packages 2>/dev/null || pip3 install Pillow",
+    "}",
+    "",
+    "# --- Create frames directory ---",
+    'FRAMES_DIR="${TMPDIR:-/tmp}/volley_frames_$$"',
+    'mkdir -p "$FRAMES_DIR"',
+    'export FRAMES_DIR',
+    'trap "rm -rf $FRAMES_DIR" EXIT',
+    'echo "Output: $OUTPUT"',
+    'echo ""',
+    "",
+    "# --- Python keyframe generator ---",
+    "python3 << 'PYTHON_SCRIPT'",
+    "import json, os, sys",
+    "import base64, io",
+    "from PIL import Image, ImageDraw, ImageFont",
+    "",
+    "WIDTH, HEIGHT = 1920, 1080",
+    'FRAMES_DIR = os.environ.get("FRAMES_DIR", "/tmp/volley_frames")',
+    "QR_B64 = 'iVBORw0KGgoAAAANSUhEUgAAASwAAAEsCAYAAAB5fY51AAAAAklEQVR4AewaftIAABFGSURBVO3BUY4st5YEwXCi979lH/0NcEABVGWq+lIvzEhi/jBqbgDklJoJyKRmB8gJNTtAJjUTkEnNE0BOqfmTAPlNaiYgT6g5BeRPslJVdYmVqqpLrFRVXWKlquoSK1VVl/jJ31DzDUCeADKpeQLIpGZScwrINwDZUfM2ICfUTECeAHJKzQkgk5odIJOaJ4BMQE6pmYC8Tc03AJlWqqousVJVdYmVqqpLrFRVXeIn/wCQJ9Q8AeQEkEnNKTUngOyo+RSQHTVvAzKpmYDsqJmAvA3IpGYCsgNkUvOEmhNAdtS8DchvAfKEmhMrVVWXWKmqusRKVdUlVqqqLvGTy6mZgExAdtRMQE6o2QHyKTWngDyhZgIyqXkCyBNqvkHNKSBPAHmbmgnIf8lKVdUlVqqqLrFSVXWJlaqqS6xUVV3iJxdR81vUnFLzKSCn1JwCMgGZ1ExAbqBmB8gE5Ak1TwA5oab+30pV1SVWqqousVJVdYmVqqpL/OQfUPOnAXJCzRNAJjU7QCY1E5DfpOYJNZ8CsgNkUvM2NSeA7ACZ1JxSMwGZgExqdoBMar5BzTesVFVdYqWq6hIrVVWXWKmqusRP/gaQPw2QSc0E5BSQSc0E5BvU7AA5AWRHzQRkUvMEkEnNKTUTkEnNBGRHzQRkUnNKzQRkUrMDZFIzAXkbkEnNKSC/ZaWq6hIrVVWXWKmqusRKVdUl8C+pVwF5m5oTQE6pOQFkR82ngDyh5hSQSc0E5G1qdoBMaiYgk5r/VStVVZdYqaq6xEpV1SVWqqousVJVdYmfPATklJoJyCk1E5BJzQTklJpvUPMEkEnNDpATQE4B+ZMA2VEzAZnUPAHklJoJyKRmArKj5k8C5JSaEytVVZdYqaq6xEpV1SVWqqouQRKzoWYCMqnZATKpOQHkW9RMQE6o2QEyqZmATGp2gExqJiCn1JwAsqNmAnJCzRNATqn5FJA/jZodIN+g5gSQJ9RMK1VVl1ipqrrESlXVJVaqqi6Bf8mXAHlCzQRkUvMEkEnNE0DepmYCsqNmAjKpOQVkUnMCyI6aTwE5pWYCckrNBOSUmhNAJjU7QCY1E5BJzRNAnlAzAZlWqqousVJVdYmVqqpLrFRVXeIHyI6aE0B21Exq/kuA7Kj5lJodICfUPAHkG9Q8AeSUmhNqnlAzAdkB8icBsqNmAjKpOQVkAjKpmVaqqi6xUlV1iZWqqkusVFVdYqWq6hI/+RtAJjVvA3JKzaRmAjKpOaXmCSCTmv8aNW8DckLNBGQHyKTmbUAmNTtAJjUTkFNqJiCTmlNAJjUTkFNqJiAnVqqqLrFSVXWJlaqqS6xUVV3iR80OkCeATGomNaeATGomNaeAnFBzSs0E5BuAPKFmArID5BvUTEAmNTtAPgVkR82kZgLypwEyqXlCzQTkbStVVZdYqaq6xEpV1SVWqqou8QPk36BmAvKEmhNAJjU7aiYgE5BvUHMKyCk1E5An1ExAJjVPAHlCzQTkN6n5BjUngDwB5Ak1J1aqqi6xUlV1iZWqqkusVFVdgiTmX6BmAjKpmYCcUjMBmdTsAPmUmh0gn1LzBJAdNROQJ9ScADKp2QEyqTkBZEfNCSCTmn8DkBNqJiD/C9RMK1VVl1ipqrrESlXVJVaqqi6xUlV1iR81O0AmNROQHSCTmgnIKTWfArKj5hvUTECeAHIKyAk1E5BTQP40QCY1TwCZ1ExAdtRMQCYgp9S8Dcik5gSQHTUngEwrVVWXWKmqusRKVdUlVqqqLvEDZEfNBGRSswNkAjKpuQGQbwBySs0pIN+gZgJySs0JIE8A+U1ATqiZgOwAmdRMQE6peRuQT61UVV1iparqEitVVZdYqaq6BEnMJdRMQL5BzSkgk5oJyKRmB8gTaiYgk5pTQCY13wBkUrMD5ISatwHZUTMBeULNp4DsqJmAnFDzBJBpparqEitVVZdYqaq6xEpV1SV+8g+omYDsqPktap4AcgM1E5AdIJOaJ9RMQL5BzSk1E5AngJxQswPkhJpTQE6omdS8DcjbVqqqLrFSVXWJlaqqS6xUVV1iparqEviXbAB5Qs0JIJOaHSCTmhNA3qZmB8gJNaeAfIOaCci3qJmAPKFmAnJCzSkgp9S8DcgJNaeATGomIJOat61UVV1iparqEitVVZdYqaq6xE/+hpoJyKRmB8gJNROQ/1VATqk5BWRSMwGZ1OwAuQGQSc0EZALybwAyqZmAvA3IE0B+y0pV1SVWqqousVJVdYmVqqpL/ORvAHlCzQRkAvI2IJOaHSAn1ExATqk5oeYJIG8DckrNBOQUkEnNBORtak4BmdRMQHbUTEAmNROQU2omIJOaJ4CcAvKplaqqS6xUVV1iparqEitVVZdYqaq6BEnMhpoTQHbUfArIb1IzAZnUnAIyqZmAPKFmB8jb1ExATqjZATKpeRuQE2pOAZnUnAJyQs0OkLepeRuQSc2JlaqqS6xUVV1iparqEitVVZcgiTmk5gkg36BmArKjZgLyW9ScAvKEmgnIE2reBmRS8wSQE2qeALKj5gSQSc3bgJxSMwE5pWYCcmKlquoSK1VVl1ipqrrESlXVJX7yLwEyqXkCyKTmt6jZATKpmYCcAnJCzSkgT6iZgExqJiA7aiY1E5An1JwAsqNmAvINQHbUTEBOqNkBMgGZ1ExATqk5sVJVdYmVqqpLrFRVXWKlquoS+JdsAJnUnALyDWpOAHmbmlNAnlDzBJATaiYgv0nN24A8oeYJIJOaE0B21ExA/jRqPrVSVXWJlaqqS6xUVV1iparqEitVVZcgiTmkZgJySs0TQD6lZgfICTVvAzKp+TcAeZuaTwH5TWomIE+o+QYgp9RMQCY1TwD5hpWqqkusVFVdYqWq6hIrVVWX+FHzm4BMat4GZEfNCSBvU/M2IE+omYCcAjKpeULNBGRSswNkAjKpmYDsqDkBZEfNCSCTmlNAngAyqXlCzQkg00pV1SVWqqousVJVdYmVqqpL/OQfAPI2NU+omYCcAjKpmdRMQN4GZEfNBGRSswPkG9R8g5oJyBNAJjU7QCY1k5odIJOaE0BOqZmAnFLzKTU7QCY1J1aqqi6xUlV1iZWqqkusVFVd4if/gJoJyCkgfxo1E5A/DZBJzQTklJoJyCkgb1MzAZnU/CY1T6iZgJxQ8zYgbwPytpWqqkusVFVdYqWq6hIrVVWXWKmqusRP/gaQSc2k5jcBuYGaCcgTQE6pOaHmG4CcUvOEmgnIpOYUkCfUnFAzAXlCzQRkR80EZFIzAXlCzbRSVXWJlaqqS6xUVV1iparqEj9AvgXIE2omNROQSc3b1OwA+QY1E5C3ATmlZgIyqdkBckLNb1IzAZnUnFJzQs0OkEnNBOQJNROQSc0TQKaVqqpLrFRVXWKlquoSK1VVl8C/5EuATGpOAZnUTEBOqfkUkB01J4BManaAnFBzCsgJNTtAPqXmFJATanaA/Jeo2QEyqZmATGp2gLxNzQTkxEpV1SVWqqousVJVdYmVqqpL/ADZUXMCyBNATqmZgJxQswPkU2q+Rc0E5BSQE2qeUHMCyCk1E5AJyI6aE0BOqZmAnFIzAXkbkEnNBOSUmgnIpOZtK1VVl1ipqrrESlXVJVaqqi6xUlV1CZKYQ2omIDtqJiCTmgnIt6g5AeQ3qTkB5FvUfArIE2reBmRS828AMqmZgDyhZgIyqdkBckLNKSAn1EwrVVWXWKmqusRKVdUlVqqqLoF/ySEgk5odIJOaCcgpNSeAfIOaJ4B8i5oJyG9R8wSQSc3bgOyomYCcUjMBOaHmFJATam6wUlV1iZWqqkusVFVdYqWq6hI/+RtATgB5Qs0E5BSQE2pOAZnUnAIyqflNQCY1E5BTaiYgk5oJyCk1k5qbAZnUnACyo+aEmieATGomIDtqJiCTmmmlquoSK1VVl1ipqrrESlXVJUhi/gVqTgCZ1LwNyCk1E5BJzRNAJjWngExqdoD8FjVvAzKp2QEyqZmAnFIzAZnUPAHklJoTQCY1TwA5peZTK1VVl1ipqrrESlXVJVaqqi6xUlV1iR81O0AmNROQU0AmNROQHTVvU/M2IJOat6mZgOyomYB8A5BTak6omYC8Tc0OkEnNKSCTmhNqTgGZ1ExAdtRMQCY1E5AdIJ9aqaq6xEpV1SVWqqousVJVdYmf/A01TwA5AeQJIJOaU0BOqJmA7Kj5FJBTat6m5hSQT6k5BeQb1HyLmgnIpOY3ATkB5JSaT61UVV1iparqEitVVZdYqaq6BEnMhpongExqTgA5peYbgExqTgF5Qs0EZFLzLUAmNU8AmdRMQE6pOQHkbWp2gExqJiCTmh0gn1JzCsgJNTtAPrVSVXWJlaqqS6xUVV1iparqEitVVZcgiTmk5hSQT6n5FiCTmhNAdtScAPKEmieATGreBuSUmgnIE2pOADmlZgJySs2ngDyh5hSQE2pOAZnUTECmlaqqS6xUVV1iparqEitVVZf4yd9QMwGZ1DyhZgLyLWpOAJnU7ACZ1DyhZgIyqTml5gSQHTVvAzKpeQLICTVvU/M2NTtA3qbmU0DetlJVdYmVqqpLrFRVXWKlquoS+JdsAPnTqDkB5JSaCcikZgLyv0zNBOQJNROQE2p2gExqJiCTmlNA3qZmArKj5huATGq+YaWq6hIrVVWXWKmqusRKVdUlSGI21JwAsqNmAjKpmYCcUjMBOaXmBJBJzQ6QE2omIDtqngByQs0EZEfNBGRSMwE5peYEkN+k5hSQSc0TQCY1E5BTak4AOaXmUytVVZdYqaq6xEpV1SVWqqousVJVdYmf/ANAJjVPAJnU7AD5lJon1JxSMwH5TWo+pWYHyNvUvE3NBGRS8wSQU2omIJOaCcgTaiYgO0AmNSfU7AD51EpV1SVWqqousVJVdYmVqqpL/ORvADkB5JSaE0C+BcgJNaeAvA3Ib1FzSs0EZFKzA+Qb1LxNzSkgJ4BMat6mZgfIBGRS8w0rVVWXWKmqusRKVdUlVqqqLoF/yS8C8oSaJ4BMak4A2VFzAyC3UjMBeULNBGRHzQTklJoTQP5r1ExATqxUVV1iparqEitVVZdYqaq6BP4llwByQs3bgDyhZgJySs0E5Ak1J4DsqPkUkB01J4BManaAfIOaCcgpNROQU2omICfUPAFkUrMDZFJzYqWq6hIrVVWXWKmqusRKVdUlVqqqLvED5E+j5m1AdtRMQCY1p4CcUDMB2QHyNiBvAzKpOQXkU0B21ExAJjWngJxQ8zY13wJkUnMCyNtWqqousVJVdYmVqqpLrFRVXYIkZkPNNwCZ1JwC8g1qJiA7at4G5Ak1J4CcUvMpIDtqJiCTmieAnFDzbwAyqTkB5G1qngDyNjXTSlXVJVaqqi6xUlV1iZWqqkv85B8A8oSaJ4B8Ss0OkEnNCTVPAJnU7KiZgExqdoBMap4A8g1qTgDZUTOpmYB8i5oJyAk1TwCZgHyLmgnIiZWqqkusVFVdYqWq6hIrVVWX+Mnl1JwAsqPmU0CeUDMBeQLIjpoJyAk1O0BOqJmA7AA5oeYUkEnNpGYCsqNmAjKp2QEyqZmATEBOqfkGNaeATGpOrFRVXWKlquoSK1VVl1ipqrrESlXVJX5yETUTkEnNE0AmNZOaJ4BMak4BmdTsADmh5pSaE0CeUHNCzQ6QCcikZlKzA+QEkB01E5ATan6TmgnIpOYUkBMrVVWXWKmqusRKVdUlVqqqLvGTf0DNn0bNCTU7QCY1E5BJzduAfIuatwGZ1ExAdtRMQCY1E5AdNROQCcik5pSaU0AmNSeAvE3NDpATaiYgb1upqrrESlXVJVaqqi6xUlV1CZKYP4yaJ4BMap4A8g1qdoCcULMD5ISaCciOmhNAJjU7QCY1fxogb1PzNiCTmgnIE2omIDtqPrVSVXWJlaqqS6xUVV1iparqEv8HcPmq7WF7orEAAAAASUVORK5CYII='",
+    "",
+    "entries = json.loads('" + jsonData.replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "')",
+    "",
+    "GREEN = (0, 255, 0)",
+    "WHITE = (255, 255, 255)",
+    "CYAN = (0, 204, 255)",
+    "BLACK = (0, 0, 0)",
+    "",
+    "# Try to load a nice font, fall back to default",
+    "def load_font(size):",
+    "    font_paths = [",
+    '        "/System/Library/Fonts/Helvetica.ttc",',
+    '        "/System/Library/Fonts/SFNSDisplay.ttf",',
+    '        "/Library/Fonts/Arial.ttf",',
+    '        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",',
+    '        "C:/Windows/Fonts/arial.ttf",',
+    "    ]",
+    "    for fp in font_paths:",
+    "        try:",
+    "            return ImageFont.truetype(fp, size)",
+    "        except (IOError, OSError):",
+    "            continue",
+    "    return ImageFont.load_default()",
+    "",
+    "font_score = load_font(72)",
+    "font_set = load_font(36)",
+    "",
+    "def draw_score_frame(active):",
+    "    img = Image.new('RGB', (WIDTH, HEIGHT), GREEN)",
+    "    draw = ImageDraw.Draw(img)",
+    "    if not active or active.get('blank'):",
+    "        return img",
+    "    if active.get('type') == 'qr':",
+    "        # Full score bar",
+    "        score_text = active['score']",
+    "        bbox = draw.textbbox((0, 0), score_text, font=font_score)",
+    "        tw = bbox[2] - bbox[0]",
+    "        sx = (WIDTH - tw) // 2",
+    "        sy = HEIGHT - 130",
+    "        for dx in range(-3, 4):",
+    "            for dy in range(-3, 4):",
+    "                draw.text((sx + dx, sy + dy), score_text, font=font_score, fill=BLACK)",
+    "        draw.text((sx, sy), score_text, font=font_score, fill=WHITE)",
+    "        sy2 = HEIGHT - 180",
+    "        set_text = active['set_info']",
+    "        bbox2 = draw.textbbox((0, 0), set_text, font=font_set)",
+    "        tw2 = bbox2[2] - bbox2[0]",
+    "        sx2 = (WIDTH - tw2) // 2",
+    "        for dx in range(-2, 3):",
+    "            for dy in range(-2, 3):",
+    "                draw.text((sx2 + dx, sy2 + dy), set_text, font=font_set, fill=BLACK)",
+    "        draw.text((sx2, sy2), set_text, font=font_set, fill=CYAN)",
+    "        title_text = active.get('title', '')",
+    "        if title_text:",
+    "            for dx in range(-2, 3):",
+    "                for dy in range(-2, 3):",
+    "                    draw.text((80 + dx, sy2 + dy), title_text, font=font_set, fill=BLACK)",
+    "            draw.text((80, sy2), title_text, font=font_set, fill=CYAN)",
+    "        sets_text = active.get('sets_score', '')",
+    "        if sets_text:",
+    "            bbox3 = draw.textbbox((0, 0), sets_text, font=font_set)",
+    "            tw3 = bbox3[2] - bbox3[0]",
+    "            sx3 = WIDTH - 80 - tw3",
+    "            for dx in range(-2, 3):",
+    "                for dy in range(-2, 3):",
+    "                    draw.text((sx3 + dx, sy2 + dy), sets_text, font=font_set, fill=BLACK)",
+    "            draw.text((sx3, sy2), sets_text, font=font_set, fill=CYAN)",
+    "        # QR card: right-aligned, bigger",
+    "        QR_SIZE = 260",
+    "        PILL_W, PILL_R = 340, 14",
+    "        TITLE_H, URL_H = 46, 36",
+    "        PILL_H = TITLE_H + QR_SIZE + URL_H",
+    "        MARGIN = 60",
+    "        pill_x = WIDTH - PILL_W - MARGIN",
+    "        pill_y = sy2 - PILL_H - 16",
+    "        draw.rounded_rectangle(",
+    "            [pill_x, pill_y, pill_x + PILL_W, pill_y + PILL_H],",
+    "            radius=PILL_R, fill=(255, 255, 255)",
+    "        )",
+    "        font_claim = load_font(22)",
+    "        card_cx = pill_x + PILL_W // 2",
+    "        draw.text((card_cx, pill_y + 12), 'titles made with ScoreLayer',",
+    "                  font=font_claim, fill=(17, 17, 17), anchor='mt')",
+    "        try:",
+    "            qr_img = Image.open(io.BytesIO(base64.b64decode(QR_B64))).resize((QR_SIZE, QR_SIZE))",
+    "            img.paste(qr_img, (pill_x + (PILL_W - QR_SIZE) // 2, pill_y + TITLE_H))",
+    "        except Exception:",
+    "            pass",
+    "        font_url = load_font(16)",
+    "        draw.text((card_cx, pill_y + TITLE_H + QR_SIZE + 8), 'jpasotto.github.io/scorelayer-volley',",
+    "                  font=font_url, fill=(85, 85, 85), anchor='mt')",
+    "        return img",
+    "    if active and not active.get('blank'):",
+    "        # -- Score line (large, centered near bottom) --",
+    "        score_text = active['score']",
+    "        bbox = draw.textbbox((0, 0), score_text, font=font_score)",
+    "        tw = bbox[2] - bbox[0]",
+    "        sx = (WIDTH - tw) // 2",
+    "        sy = HEIGHT - 130",
+    "        for dx in range(-3, 4):",
+    "            for dy in range(-3, 4):",
+    "                draw.text((sx + dx, sy + dy), score_text, font=font_score, fill=BLACK)",
+    "        draw.text((sx, sy), score_text, font=font_score, fill=WHITE)",
+    "",
+    "        # -- Highlight star (gold) --",
+    "        if active.get('highlight'):",
+    "            GOLD = (234, 179, 8)",
+    "            star_text = '\u2605'",
+    "            star_bbox = draw.textbbox((0, 0), star_text, font=font_score)",
+    "            star_w = star_bbox[2] - star_bbox[0]",
+    "            star_x = sx - star_w - 15",
+    "            for dx in range(-3, 4):",
+    "                for dy in range(-3, 4):",
+    "                    draw.text((star_x + dx, sy + dy), star_text, font=font_score, fill=BLACK)",
+    "            draw.text((star_x, sy), star_text, font=font_score, fill=GOLD)",
+    "            hl_note = active.get('highlightNote')",
+    "            if hl_note:",
+    "                note_font = load_font(28)",
+    "                note_text = '[' + hl_note + ']'",
+    "                note_bbox = draw.textbbox((0, 0), note_text, font=note_font)",
+    "                note_w = note_bbox[2] - note_bbox[0]",
+    "                note_x = (WIDTH - note_w) // 2",
+    "                note_y = sy + 80",
+    "                for dx in range(-2, 3):",
+    "                    for dy in range(-2, 3):",
+    "                        draw.text((note_x + dx, note_y + dy), note_text, font=note_font, fill=BLACK)",
+    "                draw.text((note_x, note_y), note_text, font=note_font, fill=GOLD)",
+    "",
+    "        # -- Info row: [title left]  [Set N center]  [Sets A:B right] --",
+    "        sy2 = HEIGHT - 180",
+    "",
+    "        # Center: Set N",
+    "        set_text = active['set_info']",
+    "        bbox2 = draw.textbbox((0, 0), set_text, font=font_set)",
+    "        tw2 = bbox2[2] - bbox2[0]",
+    "        sx2 = (WIDTH - tw2) // 2",
+    "        for dx in range(-2, 3):",
+    "            for dy in range(-2, 3):",
+    "                draw.text((sx2 + dx, sy2 + dy), set_text, font=font_set, fill=BLACK)",
+    "        draw.text((sx2, sy2), set_text, font=font_set, fill=CYAN)",
+    "",
+    "        # Left: match title (optional)",
+    "        title_text = active.get('title', '')",
+    "        if title_text:",
+    "            for dx in range(-2, 3):",
+    "                for dy in range(-2, 3):",
+    "                    draw.text((80 + dx, sy2 + dy), title_text, font=font_set, fill=BLACK)",
+    "            draw.text((80, sy2), title_text, font=font_set, fill=CYAN)",
+    "",
+    "        # Right: Sets score",
+    "        sets_text = active.get('sets_score', '')",
+    "        if sets_text:",
+    "            bbox3 = draw.textbbox((0, 0), sets_text, font=font_set)",
+    "            tw3 = bbox3[2] - bbox3[0]",
+    "            sx3 = WIDTH - 80 - tw3",
+    "            for dx in range(-2, 3):",
+    "                for dy in range(-2, 3):",
+    "                    draw.text((sx3 + dx, sy2 + dy), sets_text, font=font_set, fill=BLACK)",
+    "            draw.text((sx3, sy2), sets_text, font=font_set, fill=CYAN)",
+    "    return img",
+    "",
+    "# Count keyframes to generate",
+    "num_kf = len(entries)",
+    "needs_blank = len(entries) > 0 and entries[0]['start'] > 0",
+    'print(f"Generating {num_kf} keyframes...", flush=True)',
+    "",
+    "# Generate blank green frame (for gap before first score event)",
+    "if needs_blank:",
+    "    blank = Image.new('RGB', (WIDTH, HEIGHT), GREEN)",
+    '    blank.save(os.path.join(FRAMES_DIR, "blank.png"))',
+    "",
+    "# Generate one PNG per score change",
+    "for i, entry in enumerate(entries):",
+    "    img = draw_score_frame(entry)",
+    '    img.save(os.path.join(FRAMES_DIR, f"kf_{i:04d}.png"))',
+    '    print(f"\\r  {i + 1}/{num_kf}", end="", flush=True)',
+    "",
+    'print("\\r  Done! All keyframes rendered.          ")',
+    "",
+    "# Write concat demuxer file",
+    'concat_path = os.path.join(FRAMES_DIR, "concat.txt")',
+    "with open(concat_path, 'w') as f:",
+    "    if needs_blank:",
+    "        gap = entries[0]['start']",
+    "        f.write(\"file 'blank.png'\\n\")",
+    "        f.write(f\"duration {gap:.3f}\\n\")",
+    "    for i, entry in enumerate(entries):",
+    "        duration = entry['end'] - entry['start']",
+    "        f.write(f\"file 'kf_{i:04d}.png'\\n\")",
+    "        f.write(f\"duration {duration:.3f}\\n\")",
+    "    # FFmpeg concat demuxer requires the last file listed twice",
+    "    last_i = len(entries) - 1",
+    "    f.write(f\"file 'kf_{last_i:04d}.png'\\n\")",
+    "",
+    'print("Concat file written.", flush=True)',
+    "PYTHON_SCRIPT",
+    "",
+    "# --- Check Python succeeded ---",
+    'if [ $? -ne 0 ]; then',
+    '  echo "ERROR: Python keyframe generation failed."',
+    "  exit 1",
+    "fi",
+    "",
+    'echo ""',
+    'echo "Encoding video with FFmpeg..."',
+    "",
+    "# --- Assemble keyframes into MP4 via concat demuxer ---",
+    "ffmpeg -y \\",
+    '  -f concat -safe 0 -i "${FRAMES_DIR}/concat.txt" \\',
+    "  -vf fps=30 \\",
+    "  -c:v libx264 -preset fast -crf 23 \\",
+    "  -pix_fmt yuv420p \\",
+    "  -movflags +faststart \\",
+    '  "$OUTPUT"',
+    "",
+    'echo ""',
+    'echo "======================================"',
+    'echo "Done! Created: $OUTPUT"',
+    'echo "======================================"',
+    'echo ""',
+    'echo "In iMovie (iOS/Mac):"',
+    'echo "  1. AirDrop the MP4 to your iPhone/iPad"',
+    'echo "  2. In iMovie, place it above your match recording"',
+    'echo "  3. Tap the overlay icon > Green/Blue Screen"',
+    'echo "  4. iMovie removes the green, leaving the score text"',
+  ].join("\n");
+  return lines;
+}
+
+// --- README generator ---
+function generateReadme(teamA, teamB) {
+  var fname = "volleyball_" + teamA + "_vs_" + teamB;
+  return [
+    "===============================================",
+    " VOLLEYBALL SCORE OVERLAY - CHROMA KEY KIT",
+    " " + teamA + " vs " + teamB,
+    "===============================================",
+    "",
+    "This folder generates a green-screen MP4 video with",
+    "the match score overlay, for use in iMovie or any editor.",
+    "",
+    "HOW IT WORKS:",
+    "  1. Python + Pillow renders one PNG per score change",
+    "     (keyframe-based, typically 100-200 images)",
+    "  2. FFmpeg concat demuxer holds each image for the",
+    "     correct duration and encodes a smooth 30fps MP4",
+    "  No special FFmpeg filters or libraries are needed.",
+    "",
+    "FILES INCLUDED:",
+    "  generate_overlay.sh  - The main script (Mac/Linux)",
+    "  " + fname + ".ass    - Styled subtitle file (bonus,",
+    "                         for editors with ASS support)",
+    "  README.txt           - This file",
+    "",
+    "",
+    "=== QUICK START (MAC) ===",
+    "",
+    "  1. Install prerequisites (one-time):",
+    "       brew install ffmpeg python3",
+    "       pip3 install Pillow",
+    "",
+    "  2. Open Terminal in this folder and run:",
+    "       chmod +x generate_overlay.sh",
+    "       ./generate_overlay.sh",
+    "",
+    "  3. Output: " + fname + "_overlay.mp4",
+    "",
+    "",
+    "=== USING THE OVERLAY IN iMOVIE ===",
+    "",
+    "  iPhone/iPad:",
+    "   a) AirDrop the MP4 to your device",
+    "   b) Open iMovie, load your match recording",
+    "   c) Tap + to add the overlay MP4",
+    "   d) Place it ABOVE your match video in timeline",
+    "   e) Tap the overlay clip > overlay icon",
+    "   f) Select 'Green/Blue Screen'",
+    "   g) iMovie removes the green, leaving score text",
+    "",
+    "  Mac:",
+    "   a) Import both videos into iMovie",
+    "   b) Drag overlay above match video in timeline",
+    "   c) Click Video Overlay Settings (two rectangles)",
+    "   d) Choose 'Green/Blue Screen'",
+    "   e) Adjust softness if needed",
+    "",
+    "",
+    "=== USING IN FINAL CUT PRO ===",
+    "",
+    "   a) Import overlay MP4 into your event",
+    "   b) Place as connected clip above match video",
+    "   c) Effects browser > search 'Keyer'",
+    "   d) Drag Keyer effect onto overlay clip",
+    "",
+    "",
+    "=== INSTRUCTIONS FOR WINDOWS ===",
+    "",
+    "  Prerequisites:",
+    "   - Python 3: https://www.python.org/downloads/",
+    "     (Check 'Add to PATH' during install)",
+    "   - FFmpeg: https://www.gyan.dev/ffmpeg/builds/",
+    "     (Download essentials, add bin/ to PATH)",
+    "   - Pillow: pip install Pillow",
+    "",
+    "  Option A - Git Bash (recommended):",
+    "    Right-click folder > Git Bash Here, then:",
+    "      chmod +x generate_overlay.sh",
+    "      ./generate_overlay.sh",
+    "",
+    "  Option B - WSL:",
+    "    Open WSL, navigate to folder, run the script.",
+    "",
+    "",
+    "=== TROUBLESHOOTING ===",
+    "",
+    "Q: 'No module named PIL'",
+    "A: Run: pip3 install Pillow",
+    "   (The script tries to auto-install it, but may",
+    "   need manual install on some systems.)",
+    "",
+    "Q: Script is slow",
+    "A: The script renders one PNG per score change",
+    "   (typically 100-200 images), then uses FFmpeg's",
+    "   concat demuxer to hold each image for the correct",
+    "   duration. Rendering completes in seconds, not",
+    "   minutes.",
+    "",
+    "Q: Green edges visible in iMovie",
+    "A: Adjust the softness/clean-up slider on the",
+    "   Green/Blue Screen overlay settings.",
+    "",
+    "Q: Video doesn't sync with match recording",
+    "A: The overlay starts from the SYNC point pressed",
+    "   during the match. Align the overlay's start with",
+    "   that same moment in your match recording.",
+    "",
+    "",
+    "Generated by ScoreLayer Volley",
+    ""
+  ].join("\n");
+}
+
+
+
+// --- CSV parser (for import/recovery) ---
+function parseCSVToEntries(csvText, matchTitle) {
+  var lines = csvText.trim().split("\n");
+  if (lines.length < 2) return { error: "CSV must have a header row and at least one data row." };
+
+  var header = lines[0];
+  var cols = header.split(",").map(function(c) { return c.trim(); });
+  var iOffset = cols.indexOf("VideoOffset_ms");
+  var iSet = cols.indexOf("Set");
+  var iPA = cols.indexOf("PointsA");
+  var iPB = cols.indexOf("PointsB");
+  var iCorr = cols.indexOf("Correction");
+  var iDisplay = cols.indexOf("ScoreDisplay");
+  var iSA = cols.indexOf("SetsA");
+  var iSB = cols.indexOf("SetsB");
+  var iTitle = cols.indexOf("MatchTitle");
+  var iHL = cols.indexOf("Highlight");
+  var iHLNote = cols.indexOf("HighlightNote");
+
+  if (iOffset === -1 || iSet === -1 || iPA === -1 || iPB === -1) {
+    return { error: "CSV missing required columns: VideoOffset_ms, Set, PointsA, PointsB" };
+  }
+  var hasSetsColumns = iSA !== -1 && iSB !== -1;
+
+  // Extract team names from ScoreDisplay of first non-correction row
+  var teamA = "Home", teamB = "Away";
+  for (var t = 1; t < lines.length; t++) {
+    var testRow = parseCSVRow(lines[t]);
+    if (iCorr !== -1 && testRow[iCorr] && testRow[iCorr].trim() === "Y") continue;
+    if (iDisplay !== -1 && testRow[iDisplay]) {
+      var display = testRow[iDisplay].replace(/"/g, "").trim();
+      var match = display.match(/^(.+?)\s+\d+\s*-\s*\d+\s+(.+)$/);
+      if (match) {
+        teamA = match[1].trim();
+        teamB = match[2].trim();
+      }
+    }
+    break;
+  }
+
+  var dataRows = [];
+  for (var i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    var row = parseCSVRow(lines[i]);
+    var offset = parseInt(row[iOffset], 10);
+    if (isNaN(offset)) continue;
+    if (iCorr !== -1 && row[iCorr] && row[iCorr].trim() === "Y") continue;
+    dataRows.push({
+      offset_ms: offset,
+      setNum: parseInt(row[iSet], 10) || 1,
+      pointsA: parseInt(row[iPA], 10) || 0,
+      pointsB: parseInt(row[iPB], 10) || 0,
+      setsA: hasSetsColumns ? (parseInt(row[iSA], 10) || 0) : -1,
+      setsB: hasSetsColumns ? (parseInt(row[iSB], 10) || 0) : -1,
+      highlight: iHL !== -1 && row[iHL] && row[iHL].trim() === "Y",
+      highlightNote: iHLNote !== -1 ? (row[iHLNote] || "").replace(/"/g, "").trim() || null : null,
+    });
+  }
+
+  if (dataRows.length === 0) return { error: "No valid data rows found in CSV." };
+
+  // Read MatchTitle from CSV if no explicit title provided
+  var csvTitle = "";
+  if (iTitle !== -1 && dataRows.length > 0) {
+    var firstRow = parseCSVRow(lines[1]);
+    csvTitle = (firstRow[iTitle] || "").replace(/"/g, "").trim();
+  }
+  var title = (matchTitle || csvTitle || "").trim();
+
+  // Build entries — use exact SetsA/SetsB from CSV when available, otherwise infer from set transitions
+  var entries = [];
+  var pointLog = [];
+  var setsA = 0, setsB = 0, prevSetNum = 0, prevPointsA = 0, prevPointsB = 0;
+  for (var j = 0; j < dataRows.length; j++) {
+    var d = dataRows[j];
+    if (hasSetsColumns) {
+      setsA = d.setsA;
+      setsB = d.setsB;
+    } else {
+      // Infer from set transitions for older CSVs without SetsA/SetsB columns
+      if (d.setNum > prevSetNum && prevSetNum > 0) {
+        if (prevPointsA > prevPointsB) setsA++;
+        else if (prevPointsB > prevPointsA) setsB++;
+      }
+    }
+    prevSetNum = d.setNum;
+    prevPointsA = d.pointsA;
+    prevPointsB = d.pointsB;
+    var startSec = d.offset_ms / 1000;
+    if (startSec < 0) continue;
+    // For highlights, extend start back to rally beginning (prev row's timestamp), same set only
+    if (d.highlight && j > 0 && dataRows[j - 1].setNum === d.setNum) {
+      var rallyStartSec = dataRows[j - 1].offset_ms / 1000;
+      if (rallyStartSec >= 0) {
+        startSec = rallyStartSec;
+        // Truncate previous entry's end to avoid overlap
+        if (entries.length > 0 && !entries[entries.length - 1].blank) {
+          entries[entries.length - 1].end = Math.round(startSec * 1000) / 1000;
+        }
+      }
+    }
+    var csvNextP = j < dataRows.length - 1 ? dataRows[j + 1] : null;
+    var csvNextHighlightSameSet = csvNextP && csvNextP.highlight && csvNextP.setNum === d.setNum;
+    var rawEndSec = csvNextHighlightSameSet
+      ? (d.offset_ms / 1000)
+      : (csvNextP ? csvNextP.offset_ms / 1000 : startSec + 10);
+    var csvIsSetBreak = csvNextP && csvNextP.setNum !== d.setNum;
+    var csvSetWon = isSetWon(d.pointsA, d.pointsB, getTargetPoints(setsA, setsB));
+    var csvGapSec = rawEndSec - startSec;
+    var QR_LEAD_CSV = 20, QR_TRAIL_CSV = 40, MIN_GAP_CSV = 61;
+
+    if (csvIsSetBreak && csvSetWon && csvGapSec >= MIN_GAP_CSV) {
+      var csvNewSetsA = setsA + (d.pointsA > d.pointsB ? 1 : 0);
+      var csvNewSetsB = setsB + (d.pointsB > d.pointsA ? 1 : 0);
+      var csvQrStart = startSec + QR_LEAD_CSV;
+      var csvQrEnd   = rawEndSec - QR_TRAIL_CSV;
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec   * 1000) / 1000,
+        end:   Math.round(csvQrStart * 1000) / 1000,
+        score: teamA + "  " + d.pointsA + " : " + d.pointsB + "  " + teamB,
+        set_info: "Set " + d.setNum, title: title,
+        sets_score: "Sets " + setsA + ":" + setsB,
+        highlight: false, highlightNote: null,
+      });
+      entries.push({
+        type: 'qr',
+        start: Math.round(csvQrStart * 1000) / 1000,
+        end:   Math.round(csvQrEnd   * 1000) / 1000,
+        score: teamA + "  " + d.pointsA + " : " + d.pointsB + "  " + teamB,
+        set_info: "Set " + d.setNum, title: title,
+        sets_score: "Sets " + csvNewSetsA + ":" + csvNewSetsB,
+        highlight: false, highlightNote: null,
+      });
+      entries.push({
+        type: 'reset',
+        start: Math.round(csvQrEnd   * 1000) / 1000,
+        end:   Math.round(rawEndSec  * 1000) / 1000,
+        score: teamA + "  0 : 0  " + teamB,
+        set_info: "Set " + (d.setNum + 1), title: title,
+        sets_score: "Sets " + csvNewSetsA + ":" + csvNewSetsB,
+        highlight: false, highlightNote: null,
+      });
+    } else {
+      var endSec = csvIsSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
+      if (endSec <= startSec) continue;
+      entries.push({
+        type: 'score',
+        start: Math.round(startSec * 1000) / 1000,
+        end:   Math.round(endSec   * 1000) / 1000,
+        score: teamA + "  " + d.pointsA + " : " + d.pointsB + "  " + teamB,
+        set_info: "Set " + d.setNum, title: title,
+        sets_score: "Sets " + setsA + ":" + setsB,
+        highlight: d.highlight || false, highlightNote: d.highlightNote || null,
+      });
+      if (csvIsSetBreak) {
+        entries.push({
+          start: Math.round(endSec    * 1000) / 1000,
+          end:   Math.round(rawEndSec * 1000) / 1000,
+          blank: true,
+        });
+      }
+    }
+    // pointLog uses timestamp=offset_ms so generateYouTubeChapters/generateHighlightsSRT work with syncTimestamp=0
+    pointLog.push({
+      timestamp: d.offset_ms,
+      pointsA: d.pointsA,
+      pointsB: d.pointsB,
+      setsA: setsA,
+      setsB: setsB,
+      setNum: d.setNum,
+      setWon: isSetWon(d.pointsA, d.pointsB, getTargetPoints(setsA, setsB)),
+      highlight: d.highlight || false,
+      highlightNote: d.highlightNote || null,
+    });
+  }
+
+  entries = entries.filter(function(e) { return e.end > e.start; });
+  var highlightCount = pointLog.filter(function(p) { return p.highlight; }).length;
+  return { entries: entries, pointLog: pointLog, highlightCount: highlightCount, teamA: teamA, teamB: teamB, rowCount: dataRows.length, csvTitle: csvTitle };
+}
+
+function parseCSVRow(line) {
+  var result = [];
+  var current = "";
+  var inQuotes = false;
+  for (var i = 0; i < line.length; i++) {
+    var ch = line[i];
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === ',' && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+
+// --- WebCodecs overlay generator ---
+
+// Renders one frame onto a 2D canvas context.
+// entry = null -> blank green frame (used for the pre-match gap).
+// positionTop = true -> text at top of frame; false -> bottom (legacy).
+function renderQRFrame(ctx, entry, width, height, positionTop, qrBitmap, alpha) {
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#00ff00';
+  ctx.fillRect(0, 0, width, height);
+  if (!entry) return;
+
+  // --- Full score bar (identical to renderOverlayFrame) ---
+  ctx.shadowColor = '#000000';
+  var scoreY, infoY;
+  if (positionTop !== false) {
+    ctx.textBaseline = 'top';
+    infoY  = 50;
+    scoreY = 50 + 36 + 14;
+  } else {
+    ctx.textBaseline = 'bottom';
+    scoreY = height - 60;
+    infoY  = height - 145;
+  }
+
+  ctx.font = 'bold 72px Arial, Helvetica, sans-serif';
+  ctx.fillStyle = '#ffffff';
+  ctx.textAlign = 'center';
+  ctx.shadowBlur = 8;
+  ctx.shadowOffsetX = 3;
+  ctx.shadowOffsetY = 3;
+  ctx.fillText(entry.score, width / 2, scoreY);
+
+  ctx.font = 'bold 36px Arial, Helvetica, sans-serif';
+  ctx.fillStyle = '#00ccff';
+  ctx.shadowBlur = 4;
+  ctx.shadowOffsetX = 2;
+  ctx.shadowOffsetY = 2;
+  ctx.textAlign = 'center';
+  ctx.fillText(entry.set_info, width / 2, infoY);
+  if (entry.title) {
+    ctx.textAlign = 'left';
+    ctx.fillText(entry.title, 80, infoY);
+  }
+  if (entry.sets_score) {
+    ctx.textAlign = 'right';
+    ctx.fillText(entry.sets_score, width - 80, infoY);
+  }
+
+  ctx.shadowColor = 'transparent';
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
+
+  // --- QR card: right-aligned, bigger ---
+  var QR_SIZE = 260;
+  var PILL_W  = 340;
+  var PILL_R  = 14;
+  var MARGIN  = 60;
+  var TITLE_H = 46;
+  var URL_H   = 36;
+  var PILL_H  = TITLE_H + QR_SIZE + URL_H;
+
+  var pillX = width - PILL_W - MARGIN;
+  var pillY;
+  if (positionTop !== false) {
+    pillY = scoreY + 72 + 16;
+  } else {
+    pillY = (infoY - 36) - PILL_H - 16;
+  }
+
+  ctx.save();
+  ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
+
+  ctx.fillStyle = 'rgba(255,255,255,0.93)';
+  ctx.beginPath();
+  ctx.roundRect(pillX, pillY, PILL_W, PILL_H, PILL_R);
+  ctx.fill();
+
+  var cardCx = pillX + PILL_W / 2;
+
+  ctx.fillStyle = '#111111';
+  ctx.font = 'bold italic 22px Arial, Helvetica, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.shadowBlur = 0;
+  ctx.fillText('titles made with ScoreLayer', cardCx, pillY + 12);
+
+  if (qrBitmap) {
+    var qrX = pillX + (PILL_W - QR_SIZE) / 2;
+    var qrY = pillY + TITLE_H;
+    ctx.drawImage(qrBitmap, qrX, qrY, QR_SIZE, QR_SIZE);
+    ctx.fillStyle = '#555555';
+    ctx.font = '16px Arial, Helvetica, sans-serif';
+    ctx.fillText('jpasotto.github.io/scorelayer-volley', cardCx, qrY + QR_SIZE + 8);
+  }
+
+  ctx.restore();
+}
+
+function renderOverlayFrame(ctx, entry, width, height, positionTop, qrBitmap, alpha) {
+  if (entry && entry.type === 'qr') {
+    renderQRFrame(ctx, entry, width, height, positionTop,
+                  qrBitmap || null,
+                  alpha !== undefined ? alpha : 1.0);
+    return;
+  }
+
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#00ff00';
+  ctx.fillRect(0, 0, width, height);
+  if (!entry) return;
+
+  ctx.shadowColor = '#000000';
+
+  var scoreY, infoY;
+  if (positionTop !== false) {
+    // Top layout: info row first, score below it
+    ctx.textBaseline = 'top';
+    infoY  = 50;
+    scoreY = 50 + 36 + 14; // info height + gap
+  } else {
+    // Bottom layout (original): score near bottom, info row above it
+    ctx.textBaseline = 'bottom';
+    scoreY = height - 60;
+    infoY  = height - 145;
+  }
+
+  // Score: white, bold 72px, centered
+  ctx.font = 'bold 72px Arial, Helvetica, sans-serif';
+  ctx.fillStyle = '#ffffff';
+  ctx.textAlign = 'center';
+  ctx.shadowBlur = 8;
+  ctx.shadowOffsetX = 3;
+  ctx.shadowOffsetY = 3;
+  ctx.fillText(entry.score, width / 2, scoreY);
+
+  // Info row: cyan, bold 36px - [title left] [Set N center] [Sets A:B right]
+  ctx.font = 'bold 36px Arial, Helvetica, sans-serif';
+  ctx.fillStyle = '#00ccff';
+  ctx.shadowBlur = 4;
+  ctx.shadowOffsetX = 2;
+  ctx.shadowOffsetY = 2;
+
+  ctx.textAlign = 'center';
+  ctx.fillText(entry.set_info, width / 2, infoY);
+
+  if (entry.title) {
+    ctx.textAlign = 'left';
+    ctx.fillText(entry.title, 80, infoY);
+  }
+  if (entry.sets_score) {
+    ctx.textAlign = 'right';
+    ctx.fillText(entry.sets_score, width - 80, infoY);
+  }
+
+  // Highlight star and note
+  if (entry.highlight) {
+    ctx.font = 'bold 72px Arial, Helvetica, sans-serif';
+    var scoreWidth = ctx.measureText(entry.score).width;
+    var starWidth = ctx.measureText('\u2605').width;
+    var starX = (width / 2) - (scoreWidth / 2) - starWidth - 10;
+
+    ctx.fillStyle = '#eab308';
+    ctx.shadowColor = '#000000';
+    ctx.shadowBlur = 8;
+    ctx.shadowOffsetX = 3;
+    ctx.shadowOffsetY = 3;
+    ctx.textAlign = 'left';
+    if (positionTop !== false) {
+      ctx.textBaseline = 'top';
+      ctx.fillText('\u2605', starX, scoreY);
+    } else {
+      ctx.textBaseline = 'bottom';
+      ctx.fillText('\u2605', starX, scoreY);
+    }
+
+    if (entry.highlightNote) {
+      ctx.font = 'bold 28px Arial, Helvetica, sans-serif';
+      ctx.fillStyle = '#eab308';
+      ctx.textAlign = 'center';
+      ctx.shadowBlur = 4;
+      ctx.shadowOffsetX = 2;
+      ctx.shadowOffsetY = 2;
+      if (positionTop !== false) {
+        ctx.textBaseline = 'top';
+        ctx.fillText('[' + entry.highlightNote + ']', width / 2, scoreY + 80);
+      } else {
+        ctx.textBaseline = 'bottom';
+        ctx.fillText('[' + entry.highlightNote + ']', width / 2, height - 10);
+      }
+    }
+  }
+
+  ctx.shadowColor = 'transparent';
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
+}
+
+// Encodes a green-screen score overlay as an MP4 using WebCodecs + mp4-muxer.
+// Uses VFR: one VideoFrame per score change (~100-200 frames total).
+// Returns: { success: true, blob, filename } or { success: false, error, fallback, detail }
+async function generateOverlayMP4(entries, teamA, teamB, positionTop, onProgress) {
+  if (typeof VideoEncoder === 'undefined') {
+    return { success: false, error: "WebCodecs not supported in this browser.", fallback: true };
+  }
+  var Mp4Muxer = window.Mp4Muxer;
+  if (!Mp4Muxer) {
+    return { success: false, error: "MP4 muxer not loaded yet. Please wait a moment and try again.", fallback: false };
+  }
+  if (!entries || entries.length === 0) {
+    return { success: false, error: "No overlay entries to encode.", fallback: false };
+  }
+
+  var WIDTH = 1920, HEIGHT = 1080;
+  var MAX_CHUNK_US = 2000000; // 2 seconds max per VideoFrame (iOS VideoToolbox limit)
+
+  var totalChunks = 0;
+  for (var e = 0; e < entries.length; e++) {
+    var dur = entries[e].end - entries[e].start;
+    totalChunks += Math.ceil(dur / 2);
+  }
+  var hasBlank = entries[0].start > 0;
+  if (hasBlank) totalChunks += Math.ceil(entries[0].start / 2);
+
+  var canvas = document.createElement("canvas");
+  canvas.width = WIDTH;
+  canvas.height = HEIGHT;
+  // alpha: false -> opaque backing store; H.264 has no alpha channel and iOS
+  // VideoToolbox can reject VideoFrames created from RGBA canvas data.
+  var ctx = canvas.getContext("2d", { alpha: false });
+
+  var target = new Mp4Muxer.ArrayBufferTarget();
+  var muxer = new Mp4Muxer.Muxer({
+    target: target,
+    video: { codec: 'avc', width: WIDTH, height: HEIGHT },
+    fastStart: 'in-memory',
+  });
+
+  var encoderError = null;
+  var encodeQueueSize = 0;
+  var encoder = new VideoEncoder({
+    output: function(chunk, meta) {
+      encodeQueueSize--;
+      try { muxer.addVideoChunk(chunk, meta); } catch (err) { encoderError = err; }
+    },
+    error: function(e) { encoderError = e; console.error("VideoEncoder:", e); }
+  });
+  // avc1.4D4028 = H.264 Main Profile Level 4.0, required for 1920x1080 @ 30fps.
+  var baseConfig = {
+    codec: 'avc1.4D4028',
+    width: WIDTH,
+    height: HEIGHT,
+    bitrate: 8000000,
+  };
+  try {
+    if (typeof VideoEncoder.isConfigSupported === 'function') {
+      var support = await VideoEncoder.isConfigSupported(baseConfig);
+      if (!support.supported) {
+        return { success: false, error: "H.264 encoding at 1920x1080 is not supported in this browser. Use the Chroma Kit (.zip) fallback instead.", fallback: true };
+      }
+    }
+    encoder.configure(baseConfig);
+  } catch (configErr) {
+    return { success: false, error: "Encoder config failed: " + configErr.message, fallback: true };
+  }
+
+  var processedChunks = 0;
+
+  try {
+    // Blank green frame(s) covering the gap before the first score event.
+    if (hasBlank) {
+      renderOverlayFrame(ctx, null, WIDTH, HEIGHT, positionTop);
+      var blankBitmap = await createImageBitmap(canvas);
+      var blankEndUs = Math.round(entries[0].start * 1000000);
+      var bts = 0, blankKey = true;
+      while (bts < blankEndUs) {
+        var bdur = Math.min(MAX_CHUNK_US, blankEndUs - bts);
+        // Backpressure: wait if encoder queue is backed up
+        while (encodeQueueSize > 5) {
+          await new Promise(function(r) { setTimeout(r, 10); });
+          if (encoderError) throw encoderError;
+        }
+        var blankVf = new VideoFrame(blankBitmap, { timestamp: bts, duration: bdur });
+        encodeQueueSize++;
+        encoder.encode(blankVf, { keyFrame: blankKey });
+        blankVf.close();
+        bts += bdur;
+        blankKey = false;
+        processedChunks++;
+        if (onProgress) onProgress(Math.min(99, Math.round(processedChunks * 100 / totalChunks)));
+      }
+      blankBitmap.close();
+      if (encoderError) throw encoderError;
+    }
+
+    // Pre-resolve QR bitmap once before the loop
+    var hasQREntries = entries.some(function(e) { return e.type === 'qr'; });
+    var qrBitmap = null;
+    if (hasQREntries) {
+      try { qrBitmap = await getQRImageBitmap(); } catch(e) { /* skip QR if asset fails */ }
+    }
+
+    // One canvas render per score change, chunked into <=2-second VideoFrames.
+    for (var j = 0; j < entries.length; j++) {
+      if (encoderError) throw encoderError;
+      var entry = entries[j];
+
+      var ets = Math.round(entry.start * 1000000);
+      var ete = Math.round(entry.end * 1000000);
+      var ekey = true;
+
+      if (entry.type === 'qr') {
+        // QR entries: render per chunk to support per-chunk fade alpha
+        while (ets < ete) {
+          var edur = Math.min(MAX_CHUNK_US, ete - ets);
+          var FADE_US      = 1000000;
+          var entryStartUs = Math.round(entry.start * 1000000);
+          var entryEndUs   = Math.round(entry.end   * 1000000);
+          var chunkMidUs   = (ets + Math.min(ete, ets + MAX_CHUNK_US)) / 2;
+          var elapsedUs    = chunkMidUs - entryStartUs;
+          var remainUs     = entryEndUs - chunkMidUs;
+          var fadeIn       = Math.min(elapsedUs / FADE_US, 1.0);
+          var fadeOut      = Math.min(remainUs  / FADE_US, 1.0);
+          var frameAlpha   = Math.max(0, Math.min(fadeIn, fadeOut));
+
+          renderOverlayFrame(ctx, entry, WIDTH, HEIGHT, positionTop, qrBitmap, frameAlpha);
+          var chunkBitmap = await createImageBitmap(canvas);
+
+          while (encodeQueueSize > 5) {
+            await new Promise(function(r) { setTimeout(r, 10); });
+            if (encoderError) throw encoderError;
+          }
+          var vf = new VideoFrame(chunkBitmap, { timestamp: ets, duration: edur });
+          encodeQueueSize++;
+          encoder.encode(vf, { keyFrame: ekey });
+          vf.close();
+          chunkBitmap.close();
+          ets += edur;
+          ekey = false;
+          processedChunks++;
+          if (onProgress) onProgress(Math.min(99, Math.round(processedChunks * 100 / totalChunks)));
+        }
+      } else {
+        // Non-QR entries: render once and reuse bitmap across all chunks
+        renderOverlayFrame(ctx, entry.blank ? null : entry, WIDTH, HEIGHT, positionTop, null, 1.0);
+        var entryBitmap = await createImageBitmap(canvas);
+        while (ets < ete) {
+          var edur = Math.min(MAX_CHUNK_US, ete - ets);
+          while (encodeQueueSize > 5) {
+            await new Promise(function(r) { setTimeout(r, 10); });
+            if (encoderError) throw encoderError;
+          }
+          var vf = new VideoFrame(entryBitmap, { timestamp: ets, duration: edur });
+          encodeQueueSize++;
+          encoder.encode(vf, { keyFrame: ekey });
+          vf.close();
+          ets += edur;
+          ekey = false;
+          processedChunks++;
+          if (onProgress) onProgress(Math.min(99, Math.round(processedChunks * 100 / totalChunks)));
+        }
+        entryBitmap.close();
+      }
+    }
+
+    await encoder.flush();
+    if (encoderError) throw encoderError;
+    encoder.close();
+    muxer.finalize();
+
+    var blob = new Blob([target.buffer], { type: 'video/mp4' });
+    var filename = 'scorelayer_' + teamA + '_vs_' + teamB + '_overlay.mp4';
+    if (onProgress) onProgress(100);
+    return { success: true, blob: blob, filename: filename };
+
+  } catch (err) {
+    try { encoder.close(); } catch (x) {}
+    return {
+      success: false,
+      error: err.message || String(err),
+      fallback: true,
+      detail: "Entries: " + entries.length + ", At chunk: " + processedChunks + "/" + totalChunks
+    };
+  }
+}
+
+
+// CRC32 lookup table
+var crc32Table = null;
+function crc32(bytes) {
+  if (!crc32Table) {
+    crc32Table = new Uint32Array(256);
+    for (var i = 0; i < 256; i++) {
+      var c = i;
+      for (var j = 0; j < 8; j++) {
+        c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+      }
+      crc32Table[i] = c;
+    }
+  }
+  var crc = 0xFFFFFFFF;
+  for (var k = 0; k < bytes.length; k++) {
+    crc = crc32Table[(crc ^ bytes[k]) & 0xFF] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+// --- Minimal ZIP builder (store-only, no compression) ---
+function buildZip(files) {
+  var te = new TextEncoder();
+  var centralDir = [];
+  var localParts = [];
+  var offset = 0;
+
+  for (var i = 0; i < files.length; i++) {
+    var nameBytes = te.encode(files[i].name);
+    var dataBytes = te.encode(files[i].content);
+    var crcVal = crc32(dataBytes);
+
+    var local = new Uint8Array(30 + nameBytes.length + dataBytes.length);
+    var dv = new DataView(local.buffer);
+    dv.setUint32(0, 0x04034b50, true);
+    dv.setUint16(4, 20, true);
+    dv.setUint16(6, 0, true);
+    dv.setUint16(8, 0, true);
+    dv.setUint16(10, 0, true);
+    dv.setUint16(12, 0, true);
+    dv.setUint32(14, crcVal, true);
+    dv.setUint32(18, dataBytes.length, true);
+    dv.setUint32(22, dataBytes.length, true);
+    dv.setUint16(26, nameBytes.length, true);
+    dv.setUint16(28, 0, true);
+    local.set(nameBytes, 30);
+    local.set(dataBytes, 30 + nameBytes.length);
+    localParts.push(local);
+
+    var cent = new Uint8Array(46 + nameBytes.length);
+    var cdv = new DataView(cent.buffer);
+    cdv.setUint32(0, 0x02014b50, true);
+    cdv.setUint16(4, 20, true);
+    cdv.setUint16(6, 20, true);
+    cdv.setUint16(8, 0, true);
+    cdv.setUint16(10, 0, true);
+    cdv.setUint16(12, 0, true);
+    cdv.setUint16(14, 0, true);
+    cdv.setUint32(16, crcVal, true);
+    cdv.setUint32(20, dataBytes.length, true);
+    cdv.setUint32(24, dataBytes.length, true);
+    cdv.setUint16(28, nameBytes.length, true);
+    cdv.setUint16(30, 0, true);
+    cdv.setUint16(32, 0, true);
+    cdv.setUint16(34, 0, true);
+    cdv.setUint16(36, 0, true);
+    cdv.setUint32(38, 0, true);
+    cdv.setUint32(42, offset, true);
+    cent.set(nameBytes, 46);
+    centralDir.push(cent);
+
+    offset += local.length;
+  }
+
+  var centralSize = centralDir.reduce(function(a, b) { return a + b.length; }, 0);
+
+  var eocd = new Uint8Array(22);
+  var edv = new DataView(eocd.buffer);
+  edv.setUint32(0, 0x06054b50, true);
+  edv.setUint16(4, 0, true);
+  edv.setUint16(6, 0, true);
+  edv.setUint16(8, files.length, true);
+  edv.setUint16(10, files.length, true);
+  edv.setUint32(12, centralSize, true);
+  edv.setUint32(16, offset, true);
+  edv.setUint16(20, 0, true);
+
+  var totalLen = offset + centralSize + 22;
+  var result = new Uint8Array(totalLen);
+  var pos = 0;
+  for (var p1 = 0; p1 < localParts.length; p1++) {
+    result.set(localParts[p1], pos);
+    pos += localParts[p1].length;
+  }
+  for (var p2 = 0; p2 < centralDir.length; p2++) {
+    result.set(centralDir[p2], pos);
+    pos += centralDir[p2].length;
+  }
+  result.set(eocd, pos);
+  return result;
+}
+
+// --- Live Share sync helpers (no React; safe to call from anywhere). ---
+// Every call returns a Promise and never throws synchronously. When Firebase
+// is unconfigured or the user is offline these resolve to null/false so solo
+// mode keeps working. All scorekeeper writes go through atomic multi-path
+// updates so partial corruption isn't possible.
+var sync = (function() {
+  function dbRef(path) { return firebase.database().ref(path); }
+
+  function buildMetaPatch(state) {
+    return {
+      teamA: state.teamA,
+      teamB: state.teamB,
+      matchTitle: state.matchTitle || "",
+      setNumberOffset: state.setNumberOffset || 0,
+      syncTimestamp: state.syncTimestamp || null,
+      currentSet: state.currentSet,
+      setsA: state.setsA,
+      setsB: state.setsB,
+      pointsA: state.pointsA,
+      pointsB: state.pointsB,
+      matchStarted: !!state.matchStarted,
+      matchOver: !!state.matchOver,
+      extraSetMode: !!state.extraSetMode,
+    };
+  }
+
+  function createMatch(state) {
+    if (!FIREBASE_READY) return Promise.resolve(null);
+    var uid = firebase.auth().currentUser && firebase.auth().currentUser.uid;
+    if (!uid) return Promise.resolve(null);
+    var newRef = dbRef("matches").push();
+    var matchId = newRef.key;
+    var meta = buildMetaPatch(state);
+    meta.scorekeeperUid = uid;
+    meta.createdAt = firebase.database.ServerValue.TIMESTAMP;
+    meta.appVersion = APP_VERSION;
+    var update = {};
+    update["matches/" + matchId + "/meta"] = meta;
+    // Backfill any points already scored before Share was pressed.
+    (state.pointLog || []).forEach(function(p) {
+      var pRef = dbRef("matches/" + matchId + "/points").push();
+      update["matches/" + matchId + "/points/" + pRef.key] = p;
+    });
+    return firebase.database().ref().update(update).then(function() {
+      return matchId;
+    }).catch(function(err) {
+      console.warn("sync.createMatch failed:", err);
+      firebaseLastError = err;
+      return null;
+    });
+  }
+
+  function pushPoint(matchId, pointEntry, metaPatch) {
+    if (!FIREBASE_READY || !matchId) return Promise.resolve(false);
+    var pRef = dbRef("matches/" + matchId + "/points").push();
+    var update = {};
+    update["matches/" + matchId + "/points/" + pRef.key] = pointEntry;
+    if (metaPatch) {
+      Object.keys(metaPatch).forEach(function(k) {
+        update["matches/" + matchId + "/meta/" + k] = metaPatch[k];
+      });
+    }
+    return firebase.database().ref().update(update).then(function() { return true; })
+      .catch(function(err) { console.warn("sync.pushPoint failed:", err); return false; });
+  }
+
+  function replacePointLog(matchId, pointLog, metaPatch) {
+    // Used by undo: we rewrite the entire points list (not append) because
+    // undo recomputes the derived state. Server history is preserved via
+    // correction:true entries written by reducePoint, so undo is rare.
+    if (!FIREBASE_READY || !matchId) return Promise.resolve(false);
+    var update = {};
+    var pointsObj = {};
+    (pointLog || []).forEach(function(p, i) {
+      // Use a stable key derived from the index so repeated replaces don't
+      // create dangling listeners on the spectator side.
+      pointsObj["p" + String(i).padStart(6, "0")] = p;
+    });
+    update["matches/" + matchId + "/points"] = pointsObj;
+    if (metaPatch) {
+      Object.keys(metaPatch).forEach(function(k) {
+        update["matches/" + matchId + "/meta/" + k] = metaPatch[k];
+      });
+    }
+    return firebase.database().ref().update(update).then(function() { return true; })
+      .catch(function(err) { console.warn("sync.replacePointLog failed:", err); return false; });
+  }
+
+  function updateMeta(matchId, patch) {
+    if (!FIREBASE_READY || !matchId || !patch) return Promise.resolve(false);
+    var update = {};
+    Object.keys(patch).forEach(function(k) {
+      update["matches/" + matchId + "/meta/" + k] = patch[k];
+    });
+    return firebase.database().ref().update(update).then(function() { return true; })
+      .catch(function(err) { console.warn("sync.updateMeta failed:", err); return false; });
+  }
+
+  function subscribeMatch(matchId, onUpdate, onError) {
+    if (!FIREBASE_READY || !matchId) return function() {};
+    var ref = dbRef("matches/" + matchId);
+    var handler = ref.on("value", function(snap) {
+      var v = snap.val();
+      if (!v) { onUpdate(null); return; }
+      var meta = v.meta || {};
+      var pointsObj = v.points || {};
+      var pointLog = Object.keys(pointsObj).sort().map(function(k) { return pointsObj[k]; });
+      var phObj = v.parentHighlights || {};
+      var parentHighlights = Object.keys(phObj).map(function(k) {
+        var x = phObj[k]; x.id = k; return x;
+      });
+      onUpdate({ meta: meta, pointLog: pointLog, parentHighlights: parentHighlights });
+    }, function(err) {
+      console.warn("sync.subscribeMatch error:", err);
+      if (onError) onError(err);
+    });
+    return function unsubscribe() { ref.off("value", handler); };
+  }
+
+  function submitParentHighlight(matchId, payload) {
+    if (!FIREBASE_READY || !matchId) return Promise.resolve(null);
+    payload = payload || {};
+    var trimmedNote = (payload.note || "").trim().slice(0, PARENT_HIGHLIGHT_MAX_LEN);
+    var trimmedName = (payload.name || "").trim().slice(0, 40);
+    var validTag = null;
+    if (payload.tag && TECH_HIGHLIGHT_TAG_LABELS[payload.tag]) validTag = payload.tag;
+    var snap = payload.snapshot && typeof payload.snapshot === "object" ? {
+      pointsA: payload.snapshot.pointsA | 0,
+      pointsB: payload.snapshot.pointsB | 0,
+      setsA:   payload.snapshot.setsA   | 0,
+      setsB:   payload.snapshot.setsB   | 0,
+      setNum:  payload.snapshot.setNum  | 0,
+    } : null;
+    var entry = {
+      name: trimmedName || null,
+      note: trimmedNote || null,
+      tag: validTag,
+      quick: !trimmedNote,
+      snapshot: snap,
+      clientTimestamp: Date.now(),
+      serverTimestamp: firebase.database.ServerValue.TIMESTAMP,
+      deleted: false,
+    };
+    var ref = dbRef("matches/" + matchId + "/parentHighlights").push();
+    return ref.set(entry).then(function() { return ref.key; })
+      .catch(function(err) { console.warn("sync.submitParentHighlight failed:", err); return null; });
+  }
+
+  function deleteParentHighlight(matchId, highlightId) {
+    if (!FIREBASE_READY || !matchId || !highlightId) return Promise.resolve(false);
+    return dbRef("matches/" + matchId + "/parentHighlights/" + highlightId + "/deleted").set(true)
+      .then(function() { return true; })
+      .catch(function(err) { console.warn("sync.deleteParentHighlight failed:", err); return false; });
+  }
+
+  function shareUrl(matchId) {
+    var u = new URL(window.location.href);
+    u.search = "?m=" + encodeURIComponent(matchId);
+    u.hash = "";
+    return u.toString();
+  }
+
+  function qrUrl(text) {
+    return "https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=" + encodeURIComponent(text);
+  }
+
+  return {
+    createMatch: createMatch,
+    pushPoint: pushPoint,
+    replacePointLog: replacePointLog,
+    updateMeta: updateMeta,
+    subscribeMatch: subscribeMatch,
+    submitParentHighlight: submitParentHighlight,
+    deleteParentHighlight: deleteParentHighlight,
+    shareUrl: shareUrl,
+    qrUrl: qrUrl,
+    buildMetaPatch: buildMetaPatch,
+  };
+})();
+
+</script>
+<script type="text/babel">
+const { useState, useRef, useCallback, useEffect, useMemo } = React;
+
+// ─── DonateBlock ───────────────────────────────────────────────────────────
+// Shared two-channel donate UI reused in BetaModal, ManualModal, DonatePromptModal.
+function DonateBlock() {
+  const [bizumCopied, setBizumCopied] = useState(false);
+  function copyBizum(e) {
+    e.preventDefault();
+    var text = BIZUM_PHONE;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).catch(function() {});
+    } else {
+      var ta = document.createElement("textarea");
+      ta.value = text; ta.style.cssText = "position:fixed;left:-9999px;top:0;";
+      document.body.appendChild(ta); ta.select();
+      try { document.execCommand("copy"); } catch (_) {}
+      document.body.removeChild(ta);
+    }
+    setBizumCopied(true);
+    setTimeout(function() { setBizumCopied(false); }, 2200);
+  }
+  return (
+    <div className="donate-block">
+      <div className="donate-label">Support development ☕</div>
+      <a className="btn-donate-revolut" href={DONATE_URL} target="_blank" rel="noopener noreferrer">
+        💳 Donate with card (Revolut)
+      </a>
+      <div className="donate-bizum-row">
+        <span className="donate-bizum-label">Bizum</span>
+        <span className="donate-bizum-phone">{BIZUM_PHONE}</span>
+        <button className="btn btn-small donate-bizum-copy" onClick={copyBizum}>
+          {bizumCopied ? "✓ Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── ManualModal ───────────────────────────────────────────────────────────
+// Fetches ./README.md, slices the <!-- MANUAL_BEGIN --> … <!-- MANUAL_END -->
+// region, renders via marked, and embeds a DonateBlock at the bottom.
+function ManualModal(props) {
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(null);
+
+  useEffect(function() {
+    fetch("./README.md")
+      .then(function(r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      })
+      .then(function(text) {
+        var BEGIN = "<!-- MANUAL_BEGIN -->";
+        var END = "<!-- MANUAL_END -->";
+        var s = text.indexOf(BEGIN);
+        var e = text.indexOf(END);
+        var slice = (s !== -1 && e !== -1)
+          ? text.slice(s + BEGIN.length, e).trim()
+          : text;
+        setContent(slice);
+        setLoading(false);
+      })
+      .catch(function(err) {
+        setFetchError("Could not load manual. Check your connection.");
+        setLoading(false);
+      });
+  }, []);
+
+  var parsedHtml = (!loading && !fetchError && typeof marked !== "undefined")
+    ? marked.parse(content)
+    : "";
+
+  return (
+    <div className="manual-overlay" onClick={props.onClose}>
+      <div className="manual-dialog" onClick={function(e) { e.stopPropagation(); }}>
+        <div className="manual-header">
+          <div className="manual-title">📖 ScoreLayer Volley v{APP_VERSION} Manual</div>
+          <button className="manual-btn" onClick={props.onClose}>✕</button>
+        </div>
+        <div className="manual-body">
+          {loading && <div className="manual-loading">Loading manual…</div>}
+          {fetchError && <div className="manual-error">{fetchError}</div>}
+          {!loading && !fetchError && (
+            <div className="manual-content" dangerouslySetInnerHTML={{ __html: parsedHtml }} />
+          )}
+          <div className="manual-donate-section">
+            <DonateBlock />
+          </div>
+        </div>
+        <div className="manual-footer">
+          <button className="btn btn-primary" style={{ width: "100%" }} onClick={props.onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── DonatePromptModal ─────────────────────────────────────────────────────
+// Rate-limited post-export nudge. Fires at the 2nd export of the session,
+// then every 5 thereafter (2, 7, 12, 17 …).
+function DonatePromptModal(props) {
+  return (
+    <div className="donate-prompt-overlay" onClick={props.onClose}>
+      <div className="donate-prompt-dialog" onClick={function(e) { e.stopPropagation(); }}>
+        <div className="donate-prompt-icon">⚡</div>
+        <div className="donate-prompt-title">Enjoying ScoreLayer?</div>
+        <div className="donate-prompt-msg">
+          All features are free during beta. If this app saves you time at the court, consider buying me a coffee — it helps keep the project going.
+        </div>
+        <DonateBlock />
+        <button className="btn btn-small" style={{ marginTop: 14, width: "100%" }} onClick={props.onClose}>
+          Maybe later
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SpectatorView(props) {
+  const state = props.state;
+  const [name, setName] = useState(state.parentName || "");
+  const [note, setNote] = useState("");
+  const [tag, setTag] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  var disabledReason = props.liveError ? props.liveError : (state.matchOver ? "Match ended — highlights are closed." : null);
+
+  function makeSnapshot() {
+    return {
+      pointsA: state.pointsA || 0,
+      pointsB: state.pointsB || 0,
+      setsA:   state.setsA   || 0,
+      setsB:   state.setsB   || 0,
+      setNum:  state.currentSet || 1,
+    };
+  }
+
+  function submit() {
+    var trimmed = (note || "").trim();
+    if (!trimmed && !tag) return;
+    if (state.matchOver) return;
+    props.onSubmitHighlight({ name: name, note: trimmed, tag: tag, snapshot: makeSnapshot() });
+    setNote("");
+    setTag(null);
+    setModalOpen(false);
+  }
+
+  function submitQuick() {
+    if (disabledReason) return;
+    props.onSubmitHighlight({ name: name, note: "", tag: null, snapshot: makeSnapshot() });
+  }
+
+  function openModal() {
+    if (disabledReason) return;
+    setNote("");
+    setTag(null);
+    setModalOpen(true);
+  }
+
+  // Auto-close the modal if the scorekeeper ends the match while it's open.
+  useEffect(function() {
+    if (state.matchOver && modalOpen) setModalOpen(false);
+  }, [state.matchOver, modalOpen]);
+
+  // Keep local name in sync when state.parentName changes (e.g. after first submit).
+  useEffect(function() { setName(state.parentName || ""); }, [state.parentName]);
+
+  var sortedHighlights = (state.parentHighlights || [])
+    .slice()
+    .filter(function(h) { return !h.deleted; })
+    .sort(function(a, b) { return (b.clientTimestamp || 0) - (a.clientTimestamp || 0); });
+
+  // Previous-set scores derived from the pointLog the spectator already
+  // receives — no extra meta channel needed. setWon entries mark the closing
+  // point of each finished set (skip corrections defensively).
+  var prevSets = (state.pointLog || [])
+    .filter(function(p) { return p.setWon === true && !p.correction; })
+    .map(function(p) { return { setNum: p.setNum, scoreA: p.pointsA, scoreB: p.pointsB }; });
+
+  var setLabel = formatSetLabel(state.currentSet, state.setNumberOffset || 0);
+  var connected = state.matchStarted || state.pointLog.length > 0;
+
+  return (
+    <div className="spectator-screen">
+      <div className="spectator-banner">
+        <div className="live-dot-bg"></div>
+        Live spectator view
+      </div>
+      {props.liveError && (
+        <div className="parent-status err">{props.liveError}</div>
+      )}
+
+      {prevSets.length > 0 && (
+        <div className="spectator-prev-sets">
+          <div className="spectator-prev-sets-title">Previous sets</div>
+          {prevSets.map(function(s, i) {
+            var aWon = s.scoreA > s.scoreB;
+            return (
+              <div className="spectator-prev-set-row" key={i}>
+                <span className="spectator-prev-set-label">{formatSetLabel(s.setNum, state.setNumberOffset || 0)}</span>
+                <span className={"spectator-prev-set-score " + (aWon ? "a-won" : "b-won")}>
+                  <span className={aWon ? "winner" : ""}>{s.scoreA}</span>
+                  <span className="spectator-prev-set-dash">–</span>
+                  <span className={aWon ? "" : "winner"}>{s.scoreB}</span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="spectator-scoreboard">
+        <div className="spectator-team a">
+          <div className="spectator-team-name">{state.teamA || "Home"}</div>
+          <div className="spectator-points">{state.pointsA || 0}</div>
+          <div className="spectator-sets">Sets: {state.setsA || 0}</div>
+        </div>
+        <div className="spectator-sep">:</div>
+        <div className="spectator-team b">
+          <div className="spectator-team-name">{state.teamB || "Away"}</div>
+          <div className="spectator-points">{state.pointsB || 0}</div>
+          <div className="spectator-sets">Sets: {state.setsB || 0}</div>
+        </div>
+      </div>
+      <div className="spectator-set-label">
+        {connected ? setLabel : "Waiting for scorekeeper…"}
+        {state.matchOver && " · Match Over"}
+      </div>
+
+      <div className="parent-form">
+        {props.parentSubmitStatus && (
+          <div className={"parent-status " + (props.parentSubmitStatus.isError ? "err" : "ok")}>
+            {props.parentSubmitStatus.msg}
+          </div>
+        )}
+        <div className="parent-form-row">
+          <button
+            className="btn btn-primary"
+            disabled={!!disabledReason}
+            onClick={openModal}
+            style={{ flex: 2 }}
+          >
+            ★ Mark highlight
+          </button>
+          <button
+            className="btn btn-secondary"
+            disabled={!!disabledReason}
+            onClick={submitQuick}
+            title="One-tap highlight — records the current score with no note"
+            style={{ flex: 1 }}
+          >
+            ★ Quick
+          </button>
+        </div>
+        {state.matchOver && !props.liveError && (
+          <div className="share-hint" style={{ marginTop: 4 }}>Match ended. Highlights will reopen if the scorekeeper continues the match.</div>
+        )}
+      </div>
+
+      {modalOpen && (
+        <div className="share-overlay" onClick={function() { setModalOpen(false); }}>
+          <div className="share-dialog" onClick={function(e) { e.stopPropagation(); }}>
+            <div className="share-title">Mark highlight</div>
+            <div className="share-hint" style={{ marginBottom: 8 }}>Tag a great moment so it shows up in the final video.</div>
+            <div>
+              <label style={{ display: "block", fontSize: 11, color: "var(--text-dim)", textTransform: "uppercase", letterSpacing: 1, marginTop: 4 }}>Category (optional)</label>
+              <div className="tag-chip-row">
+                {TECH_HIGHLIGHT_TAGS.map(function(t) {
+                  var active = tag === t.value;
+                  return (
+                    <button
+                      type="button"
+                      key={t.value}
+                      className={"tag-chip" + (active ? " active" : "")}
+                      onClick={function() { setTag(active ? null : t.value); }}
+                    >{t.label}</button>
+                  );
+                })}
+              </div>
+            </div>
+            <div>
+              <label style={{ display: "block", fontSize: 11, color: "var(--text-dim)", textTransform: "uppercase", letterSpacing: 1, marginTop: 8 }}>Your name (optional)</label>
+              <input
+                type="text"
+                value={name}
+                onChange={function(e) { setName(e.target.value.slice(0, 40)); }}
+                placeholder="e.g. Mike"
+                maxLength={40}
+                style={{ width: "100%", marginTop: 4, padding: "8px 10px", borderRadius: 6, border: "1px solid var(--surface2)", background: "var(--surface2)", color: "var(--text)", fontFamily: "var(--font-mono)", fontSize: 13 }}
+              />
+            </div>
+            <div>
+              <label style={{ display: "block", fontSize: 11, color: "var(--text-dim)", textTransform: "uppercase", letterSpacing: 1, marginTop: 12 }}>Highlight note</label>
+              <textarea
+                value={note}
+                onChange={function(e) { setNote(e.target.value.slice(0, PARENT_HIGHLIGHT_MAX_LEN)); }}
+                onKeyDown={function(e) { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) submit(); }}
+                placeholder="Big dig by #7"
+                rows={3}
+                maxLength={PARENT_HIGHLIGHT_MAX_LEN}
+                autoFocus
+                style={{ width: "100%", marginTop: 4, padding: "8px 10px", borderRadius: 6, border: "1px solid var(--surface2)", background: "var(--surface2)", color: "var(--text)", fontFamily: "var(--font-mono)", fontSize: 13, resize: "vertical" }}
+              />
+              <div className="char-count" style={{ textAlign: "right", fontSize: 10, color: "var(--text-dim)" }}>{note.length}/{PARENT_HIGHLIGHT_MAX_LEN}</div>
+            </div>
+            {props.parentSubmitStatus && (
+              <div className={"parent-status " + (props.parentSubmitStatus.isError ? "err" : "ok")} style={{ marginTop: 8 }}>
+                {props.parentSubmitStatus.msg}
+              </div>
+            )}
+            <div className="share-actions" style={{ marginTop: 16 }}>
+              <button className="btn btn-secondary" style={{ flex: 1 }} onClick={function() { setModalOpen(false); }}>Cancel</button>
+              <button
+                className="btn btn-primary"
+                style={{ flex: 1 }}
+                disabled={(!note.trim() && !tag) || state.matchOver}
+                onClick={submit}
+              >
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {sortedHighlights.length > 0 && (
+        <div className="parent-list">
+          <div className="parent-list-title">Submitted highlights</div>
+          {sortedHighlights.map(function(h) {
+            var offsetMs = state.syncTimestamp ? (h.clientTimestamp - state.syncTimestamp) : null;
+            var offsetTxt = (offsetMs != null && offsetMs >= 0) ? msToChapterTime(offsetMs) : formatClockTime(h.clientTimestamp);
+            var snap = h.snapshot;
+            var setLbl = snap ? formatSetLabel(snap.setNum, state.setNumberOffset || 0) : null;
+            var scoreTxt = snap ? (snap.pointsA + "–" + snap.pointsB) : null;
+            var tagLabel = h.tag ? (TECH_HIGHLIGHT_TAG_LABELS[h.tag] || h.tag) : null;
+            return (
+              <div className="parent-entry" key={h.id}>
+                <div className="parent-entry-meta parent-entry-meta-row">
+                  <span>{offsetTxt}</span>
+                  {snap && (
+                    <span className="parent-entry-score">{setLbl} {scoreTxt}</span>
+                  )}
+                  {tagLabel && (
+                    <span className="parent-entry-tag">{"★ " + tagLabel}</span>
+                  )}
+                </div>
+                {(h.name || h.note) && (
+                  <div>
+                    {h.name && <span className="parent-entry-name">{h.name}{h.note ? ": " : ""}</span>}
+                    {h.note && <span className="parent-entry-note">{h.note}</span>}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ShareModalView(props) {
+  const state = props.state;
+  const [copyFeedback, setCopyFeedback] = useState("");
+  var url = state.matchId ? sync.shareUrl(state.matchId) : "";
+
+  function copyUrl() {
+    if (!url) return;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(function() {
+        setCopyFeedback("Copied!");
+        setTimeout(function() { setCopyFeedback(""); }, 1800);
+      });
+    } else {
+      var input = document.getElementById("share-url-input");
+      if (input) { input.select(); document.execCommand("copy"); setCopyFeedback("Copied!"); setTimeout(function() { setCopyFeedback(""); }, 1800); }
+    }
+  }
+
+  return (
+    <div className="share-overlay" onClick={props.onClose}>
+      <div className="share-dialog" onClick={function(e) { e.stopPropagation(); }}>
+        <div className="share-title">Live Share</div>
+        {!state.isShared ? (
+          <>
+            <div className="share-hint">
+              Generate a link parents in the stands can open to follow the score and submit highlight notes. The video timestamps stay aligned with your sync.
+            </div>
+            {props.liveError && (
+              <div className="parent-status err" style={{ marginTop: 12 }}>{props.liveError}</div>
+            )}
+            <div className="share-actions" style={{ marginTop: 16 }}>
+              <button className="btn btn-secondary" style={{ flex: 1 }} disabled={props.sharePending} onClick={props.onClose}>Cancel</button>
+              <button className="btn btn-primary" style={{ flex: 1 }} disabled={props.sharePending} onClick={function() { props.onStart(); }}>
+                {props.sharePending ? "Starting…" : "Start sharing"}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="share-hint">Share this link or QR with the parents:</div>
+            <div className="share-url-row">
+              <input id="share-url-input" readOnly value={url} onFocus={function(e) { e.target.select(); }} />
+              <button className="btn btn-small" onClick={copyUrl}>Copy</button>
+            </div>
+            {copyFeedback && <div className="parent-status ok">{copyFeedback}</div>}
+            {url && (
+              <div className="share-qr">
+                <img alt="QR code" src={sync.qrUrl(url)} />
+              </div>
+            )}
+            <div className="share-hint">
+              Parent submissions appear in the live point log and become YouTube chapters in the export.
+            </div>
+            <div className="share-actions">
+              <button className="btn btn-secondary" style={{ flex: 1 }} onClick={props.onClose}>Close</button>
+              <button className="btn btn-danger" style={{ flex: 1 }} onClick={props.onStop}>Stop sharing</button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function VolleyballTracker() {
+  const [screen, setScreen] = useState(SCREEN.SETUP);
+  const [state, setState] = useState(createInitialState);
+  const [showLog, setShowLog] = useState(false);
+  const [confirmAction, setConfirmAction] = useState(null);
+  const [exportModal, setExportModal] = useState(null);
+  const [copyFeedback, setCopyFeedback] = useState("");
+  const [isEncoding, setIsEncoding] = useState(false);
+  const [encodeProgress, setEncodeProgress] = useState(0);
+  const [overlayPositionTop, setOverlayPositionTop] = useState(true);
+  const [mp4Error, setMp4Error] = useState(null);
+
+  // CSV import state
+  const [csvText, setCsvText] = useState("");
+  const [csvParseResult, setCsvParseResult] = useState(null);
+  const [csvIsEncoding, setCsvIsEncoding] = useState(false);
+  const [csvEncodeProgress, setCsvEncodeProgress] = useState(0);
+  const [csvPositionTop, setCsvPositionTop] = useState(true);
+  const [csvMatchTitle, setCsvMatchTitle] = useState("");
+
+  // Autosave indicator
+  const [showAutosaved, setShowAutosaved] = useState(false);
+
+  // Beta info modal
+  const [showBetaModal, setShowBetaModal] = useState(false);
+
+  // Manual modal
+  const [showManualModal, setShowManualModal] = useState(false);
+
+  // Donate prompt (post-export nudge)
+  const [showDonatePrompt, setShowDonatePrompt] = useState(false);
+
+  // YouTube chapter validation errors modal
+  const [ytChapterErrors, setYtChapterErrors] = useState(null);
+  // Shape: { errors: string[], content: string, filename: string } | null
+
+  // Highlight pill state
+  const [highlightPrompt, setHighlightPrompt] = useState(null);
+  // Shape: { index: number, timer: timeoutId, phase: 'prompt' | 'input' | 'confirmed' } | null
+
+  // Inline note editor for the log (scorekeeper only)
+  const [noteEditIdx, setNoteEditIdx] = useState(null);
+  const [noteEditVal, setNoteEditVal] = useState("");
+
+  // Live Share state
+  const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [liveError, setLiveError] = useState(null);
+  const [sharePending, setSharePending] = useState(false);
+  const [parentSubmitStatus, setParentSubmitStatus] = useState(null); // { msg, isError }
+  const lastParentSubmitRef = useRef(0);
+
+  const prevMatchOver = useRef(false);
+
+  // Mount: parse ?m= for spectator role; otherwise check for autosave.
+  useEffect(function() {
+    var params = new URLSearchParams(window.location.search);
+    var urlMatchId = params.get("m");
+    // Restore parent name from a previous spectator session.
+    var savedName = "";
+    try { savedName = localStorage.getItem(LOCALSTORAGE_PARENT_NAME_KEY) || ""; } catch (e) {}
+    if (urlMatchId) {
+      if (!isFirebaseConfigured()) {
+        setLiveError("Live Share is unavailable in this build (no Firebase config). Please contact the scorekeeper for the score.");
+        setScreen(SCREEN.SPECTATOR);
+        setState(function(s) { return { ...s, role: "spectator", isShared: true, matchId: urlMatchId, parentName: savedName }; });
+        return;
+      }
+      setState(function(s) { return { ...s, role: "spectator", isShared: true, matchId: urlMatchId, parentName: savedName }; });
+      setScreen(SCREEN.SPECTATOR);
+      initFirebase();
+      return;
+    }
+    var saved = loadAutosave();
+    if (saved && saved.matchStarted) {
+      setConfirmAction("restore");
+      window.__scorelayer_autosave = saved;
+    }
+    // Pre-warm Firebase if configured so the Share button feels instant.
+    if (isFirebaseConfigured()) initFirebase();
+  }, []);
+
+  // Spectator: subscribe to RTDB and mirror server state into local state.
+  useEffect(function() {
+    if (state.role !== "spectator" || !state.matchId || !isFirebaseConfigured()) return undefined;
+    var unsubFn = null;
+    var cancelled = false;
+    initFirebase().then(function() {
+      if (cancelled) return;
+      unsubFn = sync.subscribeMatch(state.matchId, function(snap) {
+        if (!snap) {
+          setLiveError("Match not found. Ask the scorekeeper for a new link.");
+          return;
+        }
+        setLiveError(null);
+        var meta = snap.meta || {};
+        setState(function(s) {
+          return {
+            ...s,
+            teamA: meta.teamA || s.teamA,
+            teamB: meta.teamB || s.teamB,
+            matchTitle: meta.matchTitle || s.matchTitle,
+            setNumberOffset: meta.setNumberOffset || 0,
+            syncTimestamp: meta.syncTimestamp || null,
+            currentSet: meta.currentSet || 1,
+            setsA: meta.setsA || 0,
+            setsB: meta.setsB || 0,
+            pointsA: meta.pointsA || 0,
+            pointsB: meta.pointsB || 0,
+            matchStarted: !!meta.matchStarted,
+            matchOver: !!meta.matchOver,
+            extraSetMode: !!meta.extraSetMode,
+            pointLog: snap.pointLog,
+            parentHighlights: snap.parentHighlights,
+          };
+        });
+      }, function(err) {
+        setLiveError("Connection lost. Trying to reconnect…");
+      });
+    });
+    return function() {
+      cancelled = true;
+      if (unsubFn) unsubFn();
+    };
+  }, [state.role, state.matchId]);
+
+  // Scorekeeper: subscribe to parentHighlights only (so the moderation panel updates live).
+  useEffect(function() {
+    if (state.role !== "scorekeeper" || !state.matchId || !isFirebaseConfigured()) return undefined;
+    var unsubFn = null;
+    var cancelled = false;
+    initFirebase().then(function() {
+      if (cancelled) return;
+      unsubFn = sync.subscribeMatch(state.matchId, function(snap) {
+        if (!snap) return;
+        setState(function(s) { return { ...s, parentHighlights: snap.parentHighlights }; });
+      });
+    });
+    return function() {
+      cancelled = true;
+      if (unsubFn) unsubFn();
+    };
+  }, [state.role, state.matchId]);
+
+  // Track Match.Complete when match ends naturally
+  useEffect(function() {
+    if (state.matchOver && !prevMatchOver.current) {
+      if (state.setsA >= SETS_TO_WIN_MATCH || state.setsB >= SETS_TO_WIN_MATCH) {
+        trackEvent('Match', 'Complete');
+      }
+    }
+    prevMatchOver.current = state.matchOver;
+  });
+
+  // Autosave on every state change during match
+  useEffect(function() {
+    if (state.matchStarted && state.pointLog.length > 0) {
+      autosaveState(state);
+    }
+  }, [state]);
+
+  const startMatch = useCallback(function() {
+    setState(function(s) { return { ...s, matchStarted: true, teamA: s.teamA.trim() || "Home", teamB: s.teamB.trim() || "Away" }; });
+    setScreen(SCREEN.MATCH);
+    trackEvent('Match', 'Start');
+  }, []);
+
+  // Mirror to RTDB if scorekeeper-shared. No-op otherwise. Errors are swallowed (logged in sync.*).
+  function mirrorIfShared(s, action) {
+    if (!s.isShared || s.role !== "scorekeeper" || !s.matchId) return;
+    try { action(); } catch (e) { console.warn("mirror failed:", e); }
+  }
+
+  const handleSync = useCallback(function() {
+    setState(function(s) {
+      if (s.syncTimestamp) {
+        // Already synced — show confirmation before overwriting
+        setTimeout(function() { setConfirmAction("resync"); }, 0);
+        return s;
+      }
+      var next = { ...s, syncTimestamp: Date.now() };
+      mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { syncTimestamp: next.syncTimestamp }); });
+      return next;
+    });
+  }, []);
+
+  const scorePoint = useCallback(function(team) {
+    setState(function(s) {
+      if (s.matchOver) return s;
+      var now = Date.now();
+      var pointsA = s.pointsA, pointsB = s.pointsB, setsA = s.setsA, setsB = s.setsB, currentSet = s.currentSet;
+      if (team === "A") pointsA++; else pointsB++;
+      var target = getTargetPoints(setsA, setsB);
+      var setWon = isSetWon(pointsA, pointsB, target);
+      var newPoint = { team: team, pointsA: pointsA, pointsB: pointsB, setsA: setsA, setsB: setsB, setNum: currentSet, timestamp: now, wallClock: now, correction: false, highlight: false, highlightNote: null, setWon: setWon };
+      var newLog = s.pointLog.concat([newPoint]);
+      var matchOver = false;
+      var newSetHistory = s.setHistory.slice();
+      if (setWon) {
+        var winnerA = pointsA > pointsB;
+        newSetHistory.push({ winnerA: winnerA, scoreA: pointsA, scoreB: pointsB });
+        if (s.extraSetMode) {
+          // Extra set: record the result and return to match-over without changing setsA/setsB
+          matchOver = true;
+        } else {
+          if (winnerA) setsA++; else setsB++;
+          if (setsA >= SETS_TO_WIN_MATCH || setsB >= SETS_TO_WIN_MATCH) { matchOver = true; }
+          else { pointsA = 0; pointsB = 0; currentSet++; }
+        }
+      }
+      var next = { ...s, pointsA: pointsA, pointsB: pointsB, setsA: setsA, setsB: setsB, currentSet: currentSet, setHistory: newSetHistory, pointLog: newLog, matchOver: matchOver };
+      mirrorIfShared(s, function() { sync.pushPoint(s.matchId, newPoint, sync.buildMetaPatch(next)); });
+      return next;
+    });
+  }, []);
+
+  const reducePoint = useCallback(function(team) {
+    setState(function(s) {
+      if (s.matchOver) return s;
+      var pts = team === "A" ? s.pointsA : s.pointsB;
+      if (pts <= 0) return s;
+      var now = Date.now();
+      var newPA = team === "A" ? s.pointsA - 1 : s.pointsA;
+      var newPB = team === "B" ? s.pointsB - 1 : s.pointsB;
+      var newPoint = { team: team, pointsA: newPA, pointsB: newPB, setsA: s.setsA, setsB: s.setsB, setNum: s.currentSet, timestamp: now, wallClock: now, correction: true, highlight: false, highlightNote: null, setWon: false };
+      var newLog = s.pointLog.concat([newPoint]);
+      var next = { ...s, pointsA: newPA, pointsB: newPB, pointLog: newLog };
+      mirrorIfShared(s, function() { sync.pushPoint(s.matchId, newPoint, sync.buildMetaPatch(next)); });
+      return next;
+    });
+  }, []);
+
+  const undoLastPoint = useCallback(function() {
+    setState(function(s) {
+      if (s.pointLog.length === 0) return s;
+      var newLog = s.pointLog.slice(0, -1);
+      var setsA = 0, setsB = 0, pointsA = 0, pointsB = 0, currentSet = 1;
+      var sh = [];
+      for (var j = 0; j < newLog.length; j++) {
+        var entry = newLog[j];
+        if (entry.correction) {
+          pointsA = entry.pointsA;
+          pointsB = entry.pointsB;
+        } else {
+          if (entry.team === "A") pointsA++; else pointsB++;
+          var target = getTargetPoints(setsA, setsB);
+          if (isSetWon(pointsA, pointsB, target)) {
+            var wA = pointsA > pointsB;
+            sh.push({ winnerA: wA, scoreA: pointsA, scoreB: pointsB });
+            if (wA) setsA++; else setsB++;
+            pointsA = 0; pointsB = 0; currentSet++;
+          }
+        }
+      }
+      var next = { ...s, pointsA: pointsA, pointsB: pointsB, setsA: setsA, setsB: setsB, currentSet: currentSet, setHistory: sh, pointLog: newLog, matchOver: false };
+      // Undo rewrites the entire log (not append-only), so replace on the server too.
+      mirrorIfShared(s, function() { sync.replacePointLog(s.matchId, newLog, sync.buildMetaPatch(next)); });
+      return next;
+    });
+  }, []);
+
+  const toggleHighlight = useCallback(function(logIndex) {
+    setState(function(s) {
+      var entry = s.pointLog[logIndex];
+      if (!entry) return s;
+      var newLog = s.pointLog.slice();
+      if (entry.highlight) {
+        newLog[logIndex] = { ...newLog[logIndex], highlight: false, highlightNote: null };
+      } else {
+        newLog[logIndex] = { ...newLog[logIndex], highlight: true };
+      }
+      var next = { ...s, pointLog: newLog };
+      // Highlight toggle mutates an existing entry; replace the whole log to keep server in sync.
+      mirrorIfShared(s, function() { sync.replacePointLog(s.matchId, newLog, sync.buildMetaPatch(next)); });
+      return next;
+    });
+  }, []);
+
+  const markHighlightWithNote = useCallback(function(logIndex, note) {
+    trackEvent('Highlight', 'Mark');
+    setState(function(s) {
+      var entry = s.pointLog[logIndex];
+      if (!entry) return s;
+      var newLog = s.pointLog.slice();
+      newLog[logIndex] = { ...newLog[logIndex], highlight: true, highlightNote: note || null };
+      var next = { ...s, pointLog: newLog };
+      mirrorIfShared(s, function() { sync.replacePointLog(s.matchId, newLog, sync.buildMetaPatch(next)); });
+      return next;
+    });
+  }, []);
+
+  const saveNoteEdit = useCallback(function(logIndex, rawVal) {
+    markHighlightWithNote(logIndex, rawVal.trim() || null);
+    setNoteEditIdx(null);
+  }, [markHighlightWithNote]);
+
+  const handleStartShare = useCallback(function() {
+    if (!isFirebaseConfigured()) {
+      setLiveError("Live Share is not configured in this build.");
+      return;
+    }
+    setLiveError(null);
+    setSharePending(true);
+    initFirebase().then(function(uid) {
+      if (!uid) {
+        setSharePending(false);
+        setLiveError(describeFirebaseError(firebaseLastError) || "Could not sign in to Firebase. Check your network and try again.");
+        return;
+      }
+      // Use the most recent state captured via setState's updater so the meta seeds correctly.
+      setState(function(s) {
+        sync.createMatch(s).then(function(matchId) {
+          setSharePending(false);
+          if (!matchId) {
+            setLiveError(describeFirebaseError(firebaseLastError) || "Could not start share. Check your network and try again.");
+            return;
+          }
+          setState(function(s2) { return { ...s2, role: "scorekeeper", isShared: true, matchId: matchId }; });
+        });
+        return s;
+      });
+    });
+  }, []);
+
+  const handleStopShare = useCallback(function() {
+    setState(function(s) {
+      if (s.matchId) {
+        // Mark match as ended on the server so spectators stop submitting.
+        sync.updateMeta(s.matchId, { matchOver: true });
+      }
+      return { ...s, isShared: false, role: "solo", matchId: null };
+    });
+    setShareModalOpen(false);
+  }, []);
+
+  const handleSubmitParentHighlight = useCallback(function(payload) {
+    if (!state.matchId) return;
+    payload = payload || {};
+    var nowMs = Date.now();
+    if (nowMs - lastParentSubmitRef.current < PARENT_HIGHLIGHT_THROTTLE_MS) {
+      var waitS = Math.ceil((PARENT_HIGHLIGHT_THROTTLE_MS - (nowMs - lastParentSubmitRef.current)) / 1000);
+      setParentSubmitStatus({ msg: "Please wait " + waitS + "s before submitting again.", isError: true });
+      return;
+    }
+    lastParentSubmitRef.current = nowMs;
+    var trimmedName = (payload.name || "").trim();
+    if (trimmedName) {
+      try { localStorage.setItem(LOCALSTORAGE_PARENT_NAME_KEY, trimmedName); } catch (e) {}
+    }
+    setState(function(s) { return { ...s, parentName: trimmedName }; });
+    setParentSubmitStatus({ msg: "Submitting…", isError: false });
+    sync.submitParentHighlight(state.matchId, {
+      name: trimmedName,
+      note: payload.note || "",
+      tag: payload.tag || null,
+      snapshot: payload.snapshot || null
+    }).then(function(key) {
+      if (key) setParentSubmitStatus({ msg: "Submitted!", isError: false });
+      else setParentSubmitStatus({ msg: "Submission failed. Try again.", isError: true });
+      setTimeout(function() { setParentSubmitStatus(null); }, 3000);
+    });
+  }, [state.matchId]);
+
+  const handleDeleteParentHighlight = useCallback(function(highlightId) {
+    if (!state.matchId || !highlightId) return;
+    sync.deleteParentHighlight(state.matchId, highlightId);
+  }, [state.matchId]);
+
+  function showHighlightPill(logIndex) {
+    if (highlightPrompt && highlightPrompt.timer) {
+      clearTimeout(highlightPrompt.timer);
+    }
+    var timerId = setTimeout(function() {
+      setHighlightPrompt(null);
+    }, HIGHLIGHT_PILL_MS);
+    setHighlightPrompt({ index: logIndex, timer: timerId, phase: 'prompt' });
+  }
+
+  const resetMatch = useCallback(function() {
+    setState(createInitialState());
+    setScreen(SCREEN.SETUP);
+    setShowLog(false);
+    setConfirmAction(null);
+    setExportModal(null);
+    setMp4Error(null);
+    clearAutosave();
+  }, []);
+
+  const restoreAutosave = useCallback(function() {
+    var saved = window.__scorelayer_autosave;
+    if (saved) {
+      setState({ extraSetMode: false, setNumberOffset: 0, ...saved });
+      setScreen(SCREEN.MATCH);
+      delete window.__scorelayer_autosave;
+    }
+    setConfirmAction(null);
+  }, []);
+
+  // --- Share/download helper ---
+  function shareOrDownload(blob, filename, mimeType) {
+    var isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent);
+    if (isIOS && navigator.share && navigator.canShare) {
+      var file = new File([blob], filename, { type: mimeType });
+      if (navigator.canShare({ files: [file] })) {
+        navigator.share({ title: "ScoreLayer Export", files: [file] }).catch(function(err) {
+          if (err.name !== "AbortError") blobDownloadFallback(blob, filename);
+        });
+        return;
+      }
+    }
+    blobDownloadFallback(blob, filename);
+  }
+
+  function blobDownloadFallback(blob, filename) {
+    try {
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      a.style.display = "none";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(function() { URL.revokeObjectURL(url); }, 5000);
+    } catch (e) {
+      var reader = new FileReader();
+      reader.onload = function() {
+        var w = window.open(reader.result, "_blank");
+        if (!w) window.alert("Download blocked. Please allow pop-ups.");
+      };
+      reader.readAsDataURL(blob);
+    }
+  }
+
+  // --- Export donate nudge ---
+  // Increments a sessionStorage counter and opens DonatePromptModal at 2, 7, 12, 17 …
+  function triggerExportDonate() {
+    var key = "scorelayer_export_count";
+    var count = parseInt(sessionStorage.getItem(key) || "0", 10) + 1;
+    sessionStorage.setItem(key, String(count));
+    if (count === 2 || (count > 2 && (count - 2) % 5 === 0)) {
+      setShowDonatePrompt(true);
+    }
+  }
+
+  // --- Export functions ---
+  function openExport(type) {
+    var content = "";
+    var fname = "scorelayer_" + state.teamA + "_vs_" + state.teamB;
+    var offset = state.setNumberOffset || 0;
+    if (type === "srt") {
+      content = generateSRT(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, offset);
+      fname += ".srt";
+      if (!content) { window.alert("No sync point set or no points recorded."); return; }
+    } else if (type === "fcpxml") {
+      content = generateFCPXML(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, offset);
+      fname += ".fcpxml";
+      if (!content) { window.alert("No sync point set or no points recorded."); return; }
+    } else if (type === "ass") {
+      content = generateASS(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, offset);
+      fname += ".ass";
+      if (!content) { window.alert("No sync point set or no points recorded."); return; }
+    } else if (type === "chroma") {
+      content = generateChromaScript(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, offset);
+      fname = "generate_overlay.sh";
+      if (!content) { window.alert("No sync point set or no points recorded."); return; }
+    } else if (type === "chapters") {
+      fname += "_chapters.txt";
+      var chapters = buildYouTubeChapterList(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, offset, state.parentHighlights);
+      if (chapters.length === 0) { window.alert("No sync point set or no points recorded."); return; }
+      content = chapters.map(function(c) { return msToChapterTime(c.timeMs) + " " + c.text; }).join("\n");
+      var validation = validateYouTubeChapters(chapters);
+      if (!validation.valid) {
+        trackEvent('Export', 'Chapters');
+        setYtChapterErrors({ errors: validation.errors, content: content, filename: fname });
+        return;
+      }
+    } else if (type === "hlsrt") {
+      content = generateHighlightsSRT(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.setNumberOffset || 0, state.parentHighlights);
+      fname += "_highlights.srt";
+      if (!content) { window.alert("No highlights marked or no sync point set."); return; }
+    } else {
+      content = generateCSV(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, state.parentHighlights);
+      fname += ".csv";
+    }
+    var exportEventMap = { srt: 'SRT', fcpxml: 'FCPXML', ass: 'ASS', chroma: 'ChromaScript', chapters: 'Chapters', hlsrt: 'HlSRT', csv: 'CSV' };
+    if (exportEventMap[type]) trackEvent('Export', exportEventMap[type]);
+    setCopyFeedback("");
+    triggerExportDonate();
+    setExportModal({ type: type, content: content, filename: fname });
+  }
+
+  function downloadChromaKit() {
+    trackEvent('Export', 'ChromaKit');
+    var offset = state.setNumberOffset || 0;
+    var ass = generateASS(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, offset);
+    var sh = generateChromaScript(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, offset);
+    var readme = generateReadme(state.teamA, state.teamB);
+    if (!ass || !sh) { window.alert("No sync point set or no points recorded."); return; }
+    var fname = "scorelayer_" + state.teamA + "_vs_" + state.teamB;
+    var zipBytes = buildZip([
+      { name: fname + ".ass", content: ass },
+      { name: "generate_overlay.sh", content: sh },
+      { name: "README.txt", content: readme }
+    ]);
+    var blob = new Blob([zipBytes], { type: "application/zip" });
+    var zipFilename = fname + "_chroma_kit.zip";
+    shareOrDownload(blob, zipFilename, "application/zip");
+    triggerExportDonate();
+  }
+
+  function downloadCSV() {
+    trackEvent('Export', 'CSV');
+    var content = generateCSV(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, state.parentHighlights);
+    var fname = "scorelayer_" + state.teamA + "_vs_" + state.teamB + ".csv";
+    var blob = new Blob([content], { type: "text/csv" });
+    shareOrDownload(blob, fname, "text/csv");
+    triggerExportDonate();
+  }
+
+  async function handleGenerateMP4() {
+    if (isEncoding) return;
+
+    var entries = buildOverlayEntries(state.pointLog, state.syncTimestamp, state.teamA, state.teamB, state.matchTitle, state.setNumberOffset || 0, state.parentHighlights || []);
+    if (entries.length === 0) {
+      window.alert("No sync point set or no points recorded.");
+      return;
+    }
+
+    setIsEncoding(true);
+    setEncodeProgress(0);
+    setMp4Error(null);
+    trackEvent('Export', 'MP4Start');
+
+    var result = await generateOverlayMP4(entries, state.teamA, state.teamB, overlayPositionTop, function(pct) {
+      setEncodeProgress(pct);
+    });
+
+    setIsEncoding(false);
+
+    if (result.success) {
+      setEncodeProgress(100);
+      trackEvent('Export', 'MP4Success');
+      shareOrDownload(result.blob, result.filename, "video/mp4");
+      triggerExportDonate();
+    } else {
+      setMp4Error(result);
+    }
+  }
+
+  // --- CSV Import handlers ---
+  function handleCSVTextChange(e) {
+    var text = e.target.value;
+    setCsvText(text);
+    if (text.trim().length > 20) {
+      var parsed = parseCSVToEntries(text);
+      setCsvParseResult(parsed);
+      if (parsed.csvTitle && !csvMatchTitle) setCsvMatchTitle(parsed.csvTitle);
+    } else {
+      setCsvParseResult(null);
+    }
+  }
+
+  function handleCSVFile(e) {
+    var file = e.target.files && e.target.files[0];
+    if (!file) return;
+    var reader = new FileReader();
+    reader.onload = function() {
+      var text = reader.result;
+      setCsvText(text);
+      var parsed = parseCSVToEntries(text);
+      setCsvParseResult(parsed);
+      if (parsed.csvTitle) setCsvMatchTitle(parsed.csvTitle);
+    };
+    reader.readAsText(file);
+  }
+
+  async function handleCSVGenerateMP4() {
+    if (!csvParseResult || !csvParseResult.entries || csvIsEncoding) return;
+
+    // Re-parse with current title so overlay includes it
+    var finalResult = parseCSVToEntries(csvText, csvMatchTitle);
+    if (!finalResult.entries) finalResult = csvParseResult;
+
+    setCsvIsEncoding(true);
+    setCsvEncodeProgress(0);
+    trackEvent('Export', 'MP4Start');
+
+    var result = await generateOverlayMP4(
+      finalResult.entries, finalResult.teamA, finalResult.teamB,
+      csvPositionTop, function(pct) { setCsvEncodeProgress(pct); }
+    );
+
+    setCsvIsEncoding(false);
+
+    if (result.success) {
+      setCsvEncodeProgress(100);
+      trackEvent('Export', 'MP4Success');
+      shareOrDownload(result.blob, result.filename, "video/mp4");
+      triggerExportDonate();
+    } else {
+      setMp4Error(result);
+    }
+  }
+
+  function handleCopy() {
+    if (!exportModal) return;
+    try {
+      navigator.clipboard.writeText(exportModal.content).then(function() {
+        setCopyFeedback("Copied to clipboard!");
+        setTimeout(function() { setCopyFeedback(""); }, 3000);
+      }, function() { fallbackCopy(); });
+    } catch (e) { fallbackCopy(); }
+  }
+  function fallbackCopy() {
+    var ta = document.createElement("textarea");
+    ta.value = exportModal.content;
+    ta.style.cssText = "position:fixed;left:-9999px;top:0;";
+    document.body.appendChild(ta);
+    ta.select();
+    ta.setSelectionRange(0, ta.value.length);
+    try { document.execCommand("copy"); setCopyFeedback("Copied to clipboard!"); } catch (e) { setCopyFeedback("Select the text above and copy manually."); }
+    document.body.removeChild(ta);
+    setTimeout(function() { setCopyFeedback(""); }, 4000);
+  }
+
+  // --- Badges ---
+  var target = getTargetPoints(state.setsA, state.setsB);
+  var aAtSetPoint = state.pointsA >= target - 1 && state.pointsA > state.pointsB && state.pointsA - state.pointsB >= MIN_LEAD - 1;
+  var bAtSetPoint = state.pointsB >= target - 1 && state.pointsB > state.pointsA && state.pointsB - state.pointsA >= MIN_LEAD - 1;
+  var aAtMatchPoint = aAtSetPoint && state.setsA === SETS_TO_WIN_MATCH - 1;
+  var bAtMatchPoint = bAtSetPoint && state.setsB === SETS_TO_WIN_MATCH - 1;
+
+  // --- Highlight count ---
+  var highlightCount = state.pointLog.filter(function(p) { return p.highlight; }).length;
+
+  return (
+    <div className="app">
+      <div className="header">
+        <h1 style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          ScoreLayer Volley
+          <span className="beta-badge" onClick={function() { setShowBetaModal(true); }}>BETA</span>
+        </h1>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {screen === SCREEN.MATCH && !state.matchOver && <div className="live-dot" />}
+          <button className="manual-btn" title="User Manual" onClick={function() { setShowManualModal(true); }}>?</button>
+          {screen === SCREEN.SETUP && (
+            <button className="btn btn-small" onClick={function() { setScreen(SCREEN.CSV_IMPORT); }} style={{ fontSize: 10 }}>Import CSV</button>
+          )}
+        </div>
+      </div>
+
+      {/* ========== SETUP SCREEN ========== */}
+      {screen === SCREEN.SETUP && (
+        <div className="setup">
+          <div className="setup-title">Match Setup</div>
+          <div className="setup-subtitle">Best of 5 sets · 25 pts · Tiebreak 15</div>
+          <div className="input-group">
+            <label>Team A</label>
+            <input type="text" value={state.teamA} placeholder="Home" onChange={function(e) { var v = e.target.value; setState(function(s) { return { ...s, teamA: v }; }); }} />
+          </div>
+          <div className="input-group">
+            <label>Team B</label>
+            <input type="text" value={state.teamB} placeholder="Away" onChange={function(e) { var v = e.target.value; setState(function(s) { return { ...s, teamB: v }; }); }} />
+          </div>
+          <div className="format-info">
+            Tap <strong>+</strong> to score, <strong>&minus;</strong> to correct. Press <strong>SYNC</strong> at a known video moment to align timestamps. Match data is auto-saved.
+          </div>
+          <button className="btn btn-primary" onClick={startMatch}>Start Match</button>
+        </div>
+      )}
+
+      {/* ========== CSV IMPORT SCREEN ========== */}
+      {screen === SCREEN.CSV_IMPORT && (
+        <div className="csv-import">
+          <div className="csv-import-title">Import CSV</div>
+          <div className="csv-import-subtitle">Generate overlay MP4 from a previously exported CSV</div>
+          <div className="file-picker-row">
+            <button className="btn btn-secondary" onClick={function() { document.getElementById('csv-file-input').click(); }}>Choose CSV File</button>
+            <input type="file" id="csv-file-input" accept=".csv,text/csv" onChange={handleCSVFile} />
+            <span style={{ fontSize: 11, color: "var(--text-dim)" }}>or paste below</span>
+          </div>
+          <textarea
+            value={csvText}
+            onChange={handleCSVTextChange}
+            placeholder={"Paste CSV content here...\n\nExpected columns:\nIndex,WallClock,VideoOffset_ms,Set,PointsA,PointsB,ScoringTeam,Correction,ScoreDisplay"}
+          />
+          {csvParseResult && csvParseResult.error && (
+            <div className="parsed-info parsed-error">{csvParseResult.error}</div>
+          )}
+          {csvParseResult && csvParseResult.entries && (
+            <>
+              <div className="parsed-info">
+                Parsed <strong>{csvParseResult.rowCount}</strong> score entries for <strong>{csvParseResult.teamA}</strong> vs <strong>{csvParseResult.teamB}</strong>.
+                Duration: ~{Math.ceil(csvParseResult.entries[csvParseResult.entries.length - 1].end)}s
+              </div>
+              <div className="input-group" style={{ gap: 4 }}>
+                <label style={{ fontSize: 11, color: "var(--text-dim)", letterSpacing: 1 }}>OVERLAY TITLE</label>
+                <input
+                  type="text"
+                  value={csvMatchTitle}
+                  placeholder="e.g. U14 Girls League"
+                  onChange={function(e) { setCsvMatchTitle(e.target.value); }}
+                />
+                <span className="hint">Shown left of Set # in the overlay. Leave blank to omit.</span>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <span style={{ fontSize: 11, color: "var(--text-dim)", letterSpacing: 1 }}>POSITION:</span>
+                <div className="position-toggle">
+                  <button className={csvPositionTop ? "active" : ""} onClick={function() { setCsvPositionTop(true); }}>&#8593; Top</button>
+                  <button className={!csvPositionTop ? "active" : ""} onClick={function() { setCsvPositionTop(false); }}>&#8595; Bottom</button>
+                </div>
+              </div>
+              <button className="btn btn-success" onClick={handleCSVGenerateMP4} disabled={csvIsEncoding}>
+                {csvIsEncoding ? "Generating\u2026 " + csvEncodeProgress + "%" : "Generate Overlay MP4"}
+              </button>
+              {csvIsEncoding && (
+                <div className="progress-bar-track">
+                  <div className="progress-bar-fill" style={{ width: csvEncodeProgress + "%" }} />
+                </div>
+              )}
+              <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 8 }}>
+                <button className="btn btn-secondary" onClick={function() {
+                  var chapters = buildYouTubeChapterList(csvParseResult.pointLog, 0, csvParseResult.teamA, csvParseResult.teamB, 0);
+                  if (!chapters.length) { window.alert("No points recorded."); return; }
+                  var content = chapters.map(function(c) { return msToChapterTime(c.timeMs) + " " + c.text; }).join("\n");
+                  var fname = (csvParseResult.teamA + "_vs_" + csvParseResult.teamB).replace(/\s+/g, "_") + "_chapters.txt";
+                  setExportModal({ type: "chapters", content: content, filename: fname });
+                }}>Export YouTube Chapters</button>
+                {csvParseResult.highlightCount > 0 && (
+                  <>
+                    <div className="highlight-section-label">{"\u2605"} {csvParseResult.highlightCount} highlight{csvParseResult.highlightCount !== 1 ? "s" : ""} in CSV</div>
+                    <button className="btn btn-secondary" onClick={function() {
+                      var content = generateHighlightsSRT(csvParseResult.pointLog, 0, csvParseResult.teamA, csvParseResult.teamB, 0);
+                      if (!content) { window.alert("No highlights found."); return; }
+                      var fname = (csvParseResult.teamA + "_vs_" + csvParseResult.teamB).replace(/\s+/g, "_") + "_highlights.srt";
+                      setExportModal({ type: "hlsrt", content: content, filename: fname });
+                    }}>Export Highlights SRT</button>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+          <button className="btn btn-small" onClick={function() { setScreen(SCREEN.SETUP); setCsvText(""); setCsvParseResult(null); }} style={{ marginTop: 8 }}>&#8592; Back to Setup</button>
+        </div>
+      )}
+
+      {/* ========== MATCH SCREEN (LIVE) ========== */}
+      {screen === SCREEN.MATCH && !state.matchOver && (
+        <div className="match">
+          <div className={"sync-bar" + (state.syncTimestamp ? "" : " sync-bar-alert")}>
+            {state.syncTimestamp ? (
+              <>
+                <div className="sync-dot on" />
+                <span className="sync-status synced">{"Synced @ " + formatClockTime(state.syncTimestamp)}</span>
+                <button className="btn btn-small" onClick={handleSync}>Re-sync</button>
+              </>
+            ) : (
+              <>
+                <span className="not-synced-badge">Not Synced</span>
+                <button className={"btn btn-small btn-sync-alert"} onClick={handleSync}>Sync Now</button>
+              </>
+            )}
+            {isFirebaseConfigured() && (
+              state.isShared && state.role === "scorekeeper" ? (
+                <button
+                  className="btn btn-small"
+                  style={{ background: "rgba(34,197,94,0.15)", color: "var(--success)", marginLeft: 6 }}
+                  onClick={function() { setLiveError(null); setShareModalOpen(true); }}
+                >
+                  ● Live
+                </button>
+              ) : (
+                <button
+                  className="btn btn-small"
+                  style={{ marginLeft: 6 }}
+                  onClick={function() { setLiveError(null); setShareModalOpen(true); }}
+                >
+                  Share live
+                </button>
+              )
+            )}
+          </div>
+
+          <div className="sets-bar">
+            <div style={{ textAlign: "center" }}>
+              <div className="set-label">{state.teamA}</div>
+              <div className="set-score" style={{ color: "var(--team-a)" }}>{state.setsA}</div>
+            </div>
+            <div style={{ textAlign: "center" }}>
+              <div className="set-label">Sets</div>
+              <div className="set-divider">&#8212;</div>
+            </div>
+            <div style={{ textAlign: "center" }}>
+              <div className="set-label">{state.teamB}</div>
+              <div className="set-score" style={{ color: "var(--team-b)" }}>{state.setsB}</div>
+            </div>
+            <div style={{ marginLeft: 16, textAlign: "center" }}>
+              {state.extraSetMode && <div style={{ background: "var(--warning)", color: "#000", fontSize: 9, fontWeight: 700, letterSpacing: 1, padding: "2px 6px", borderRadius: 3, marginBottom: 2 }}>EXTRA SET</div>}
+              {(function() {
+                var lbl = formatSetLabel(state.currentSet, state.setNumberOffset || 0);
+                var isWarmup = lbl === "Warm-up";
+                return (
+                  <>
+                    <div className="set-label">{isWarmup ? "Warm-up" : "Set"}</div>
+                    <div className="set-score" style={{ color: "var(--text-dim)", fontSize: isWarmup ? 12 : undefined }}>{isWarmup ? "WU" : state.currentSet + (state.setNumberOffset || 0)}</div>
+                  </>
+                );
+              })()}
+            </div>
+          </div>
+
+          <div className="score-area">
+            <div className="score-half team-a">
+              {aAtMatchPoint && <div className="set-point-badge match-point-badge">Match Pt</div>}
+              {aAtSetPoint && !aAtMatchPoint && <div className="set-point-badge">Set Pt</div>}
+              <div className="team-name">{state.teamA}</div>
+              <button className="score-btn score-btn-plus" onClick={function() { var idx = state.pointLog.length; scorePoint("A"); showHighlightPill(idx); }}>+</button>
+              <div className="points">{state.pointsA}</div>
+              <button className="score-btn score-btn-minus" onClick={function() { reducePoint("A"); }} disabled={state.pointsA <= 0}>&minus;</button>
+            </div>
+            <div className="score-half team-b">
+              {bAtMatchPoint && <div className="set-point-badge match-point-badge">Match Pt</div>}
+              {bAtSetPoint && !bAtMatchPoint && <div className="set-point-badge">Set Pt</div>}
+              <div className="team-name">{state.teamB}</div>
+              <button className="score-btn score-btn-plus" onClick={function() { var idx = state.pointLog.length; scorePoint("B"); showHighlightPill(idx); }}>+</button>
+              <div className="points">{state.pointsB}</div>
+              <button className="score-btn score-btn-minus" onClick={function() { reducePoint("B"); }} disabled={state.pointsB <= 0}>&minus;</button>
+            </div>
+          </div>
+
+          {highlightPrompt && highlightPrompt.phase !== 'done' && !state.matchOver && (
+            <div style={{ display: 'flex', justifyContent: 'center', padding: '8px 16px' }}>
+              {highlightPrompt.phase === 'prompt' && (
+                <div
+                  className="highlight-pill"
+                  onClick={function() {
+                    if (highlightPrompt.timer) clearTimeout(highlightPrompt.timer);
+                    markHighlightWithNote(highlightPrompt.index, null);
+                    setHighlightPrompt(function(hp) { return { ...hp, phase: 'input', timer: null }; });
+                  }}
+                  onTouchStart={function(e) {
+                    // Pause auto-dismiss while finger is held on pill
+                    setHighlightPrompt(function(hp) {
+                      if (hp && hp.timer) { clearTimeout(hp.timer); }
+                      return hp ? { ...hp, timer: null } : hp;
+                    });
+                  }}
+                  onTouchEnd={function(e) {
+                    // Restart timer with extended duration on release
+                    var t = setTimeout(function() { setHighlightPrompt(null); }, HIGHLIGHT_PILL_EXTEND_MS);
+                    setHighlightPrompt(function(hp) { return hp ? { ...hp, timer: t } : hp; });
+                  }}
+                  onTouchCancel={function(e) {
+                    var t = setTimeout(function() { setHighlightPrompt(null); }, HIGHLIGHT_PILL_EXTEND_MS);
+                    setHighlightPrompt(function(hp) { return hp ? { ...hp, timer: t } : hp; });
+                  }}
+                >
+                  <span className="hl-star">&#9734;</span>
+                  <span className="hl-text">Highlight</span>
+                </div>
+              )}
+              {highlightPrompt.phase === 'input' && (
+                <div className="highlight-pill expanded">
+                  <span className="hl-star">&#9733;</span>
+                  <input
+                    className="hl-input"
+                    type="text"
+                    maxLength={30}
+                    placeholder="ace, block, rally..."
+                    autoFocus
+                    onKeyDown={function(e) {
+                      if (e.key === 'Enter') {
+                        var note = e.target.value.trim() || null;
+                        markHighlightWithNote(highlightPrompt.index, note);
+                        setHighlightPrompt(function(hp) { return { ...hp, phase: 'confirmed', timer: null }; });
+                        setTimeout(function() { setHighlightPrompt(null); }, 1000);
+                      }
+                    }}
+                    onChange={function(e) {
+                      var note = e.target.value;
+                      setHighlightPrompt(function(hp) { return { ...hp, noteInput: note }; });
+                    }}
+                  />
+                  <button className="hl-done" onClick={function() {
+                    var note = (highlightPrompt.noteInput || "").trim() || null;
+                    markHighlightWithNote(highlightPrompt.index, note);
+                    setHighlightPrompt(function(hp) { return { ...hp, phase: 'confirmed', timer: null }; });
+                    setTimeout(function() { setHighlightPrompt(null); }, 1000);
+                  }}>Done</button>
+                </div>
+              )}
+              {highlightPrompt.phase === 'confirmed' && (
+                <div className="highlight-pill confirmed">
+                  <span className="hl-star">&#9733;</span>
+                  <span className="hl-text marked">Marked!</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="controls">
+            <button className="btn btn-secondary" onClick={undoLastPoint} disabled={state.pointLog.length === 0}>Undo</button>
+            <button className="btn btn-small" onClick={function() { setShowLog(function(v) { return !v; }); }}>
+              {showLog ? "Hide Log" : "Show Log"} ({state.pointLog.length})
+            </button>
+            {state.pointLog.length > 0 && <span className="autosave-badge">auto-saved</span>}
+            {state.extraSetMode
+              ? <button className="btn btn-danger" onClick={function() { setState(function(s) {
+                  var next = { ...s, matchOver: true, extraSetMode: false };
+                  mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { matchOver: true, extraSetMode: false }); });
+                  return next;
+                }); }}>End Match</button>
+              : <button className="btn btn-danger" onClick={function() { setConfirmAction("end"); }}>End Match</button>
+            }
+          </div>
+
+          {showLog && (
+            <div className="point-log">
+              {state.pointLog.slice().reverse().map(function(p, i) {
+                var key = state.pointLog.length - 1 - i;
+                return (
+                  <div className={"log-entry" + (p.highlight ? " is-highlight" : "")} key={key}>
+                    <span className="log-time">{formatClockTime(p.wallClock)}</span>
+                    <span className="log-set">{(function() { var lbl = formatSetLabel(p.setNum, state.setNumberOffset || 0); return lbl === "Warm-up" ? "WU" : "S" + (p.setNum + (state.setNumberOffset || 0)); })()}</span>
+                    <span className="log-highlight" onClick={function(e) { e.stopPropagation(); toggleHighlight(key); }}>
+                      {p.highlight ? "\u2605" : "\u2606"}
+                    </span>
+                    <span className={"log-score " + (p.team === "A" ? "log-team-a" : "log-team-b")}>{p.pointsA} - {p.pointsB}</span>
+                    <span className="log-arrow" style={{ color: p.team === "A" ? "var(--team-a)" : "var(--team-b)" }}>
+                      {p.correction ? "\u2193" : "\u25CF"} {p.team === "A" ? state.teamA : state.teamB}{p.correction ? " (adj)" : ""}
+                    </span>
+                    {p.highlight && (
+                      noteEditIdx === key
+                        ? <input
+                            autoFocus
+                            value={noteEditVal}
+                            onChange={function(e) { setNoteEditVal(e.target.value); }}
+                            onBlur={function(e) { saveNoteEdit(key, e.target.value); }}
+                            onKeyDown={function(e) {
+                              if (e.key === "Enter") { e.preventDefault(); saveNoteEdit(key, e.target.value); }
+                              else if (e.key === "Escape") { e.preventDefault(); setNoteEditIdx(null); }
+                            }}
+                            style={{ fontFamily: "var(--font-mono)", fontSize: 12, background: "var(--surface2)", color: "var(--text)", border: "none", borderRadius: 3, padding: "1px 4px", width: 120 }}
+                          />
+                        : <span
+                            className="log-hl-note"
+                            onClick={function(e) { e.stopPropagation(); setNoteEditIdx(key); setNoteEditVal(p.highlightNote || ""); }}
+                            style={{ cursor: "pointer" }}
+                          >{p.highlightNote ? "(" + p.highlightNote + ")" : <span style={{ opacity: 0.45 }}>add note</span>}</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {showLog && state.role === "scorekeeper" && state.isShared && (state.parentHighlights || []).length > 0 && (
+            <div className="parent-list" style={{ borderTop: "1px solid var(--surface2)", borderRadius: 0, marginTop: 0 }}>
+              <div className="parent-list-title">
+                Parent highlights ({(state.parentHighlights || []).filter(function(h) { return !h.deleted; }).length})
+              </div>
+              {(state.parentHighlights || [])
+                .slice()
+                .sort(function(a, b) { return (b.clientTimestamp || 0) - (a.clientTimestamp || 0); })
+                .map(function(h) {
+                  var offsetMs = state.syncTimestamp ? (h.clientTimestamp - state.syncTimestamp) : null;
+                  var offsetTxt = (offsetMs != null && offsetMs >= 0) ? msToChapterTime(offsetMs) : "\u2014";
+                  var snap = h.snapshot;
+                  var setLbl = snap ? formatSetLabel(snap.setNum, state.setNumberOffset || 0) : null;
+                  var tagLabel = h.tag ? (TECH_HIGHLIGHT_TAG_LABELS[h.tag] || h.tag) : null;
+                  return (
+                    <div className={"parent-entry" + (h.deleted ? " parent-entry-deleted" : "")} key={h.id}>
+                      <div className="parent-entry-meta parent-entry-meta-row">
+                        <span>{formatClockTime(h.clientTimestamp)} \u00B7 video {offsetTxt}</span>
+                        {snap && (
+                          <span className="parent-entry-score">{setLbl} {snap.pointsA}\u2013{snap.pointsB}</span>
+                        )}
+                        {tagLabel && (
+                          <span className="parent-entry-tag">{"\u2605 " + tagLabel}</span>
+                        )}
+                        {!h.deleted && (
+                          <button
+                            className="parent-entry-delete-btn"
+                            onClick={function() { handleDeleteParentHighlight(h.id); }}
+                            style={{ marginLeft: "auto" }}
+                          >Delete</button>
+                        )}
+                      </div>
+                      {(h.name || h.note) && (
+                        <div>
+                          {h.name && <span className="parent-entry-name">{h.name}{h.note ? ": " : ""}</span>}
+                          {h.note && <span className="parent-entry-note">{h.note}</span>}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ========== MATCH OVER SCREEN ========== */}
+      {screen === SCREEN.MATCH && state.matchOver && (
+        <div className="match-over">
+          <div style={{ fontSize: 12, letterSpacing: 3, color: "var(--text-dim)", textTransform: "uppercase" }}>Match Complete</div>
+          <div className="winner">{state.setsA > state.setsB ? state.teamA : state.teamB} Wins</div>
+          <div className="final-score">
+            <span style={{ color: "var(--team-a)" }}>{state.setsA}</span>
+            <span style={{ color: "var(--text-dim)", margin: "0 8px" }}>&#8212;</span>
+            <span style={{ color: "var(--team-b)" }}>{state.setsB}</span>
+          </div>
+          <div className="set-details">
+            {state.setHistory.map(function(sh, i) { return <div key={i}>{formatSetLabel(i + 1, state.setNumberOffset || 0)}: {sh.scoreA}&#8211;{sh.scoreB}</div>; })}
+          </div>
+
+          {/* Editable team names */}
+          <div className="title-input-wrap">
+            <label style={{ color: "var(--team-a)" }}>Team A Name</label>
+            <input type="text" value={state.teamA} placeholder="Home" onChange={function(e) { var v = e.target.value; setState(function(s) { return { ...s, teamA: v }; }); autosaveState({ ...state, teamA: e.target.value }); }} />
+          </div>
+          <div className="title-input-wrap">
+            <label style={{ color: "var(--team-b)" }}>Team B Name</label>
+            <input type="text" value={state.teamB} placeholder="Away" onChange={function(e) { var v = e.target.value; setState(function(s) { return { ...s, teamB: v }; }); autosaveState({ ...state, teamB: e.target.value }); }} />
+          </div>
+
+          {/* Set number offset */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 6, width: "100%", maxWidth: 300, alignItems: "center" }}>
+            <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: 2, textTransform: "uppercase", color: "var(--text-dim)" }}>Set Numbering</span>
+            <div className="position-toggle" style={{ width: "100%" }}>
+              <button className={(state.setNumberOffset || 0) === -1 ? "active" : ""} onClick={function() { setState(function(s) { return { ...s, setNumberOffset: -1 }; }); }}>&#8722;1</button>
+              <button className={(state.setNumberOffset || 0) === 0 ? "active" : ""} onClick={function() { setState(function(s) { return { ...s, setNumberOffset: 0 }; }); }}>0</button>
+              <button className={(state.setNumberOffset || 0) === 1 ? "active" : ""} onClick={function() { setState(function(s) { return { ...s, setNumberOffset: 1 }; }); }}>+1</button>
+            </div>
+            {(state.setNumberOffset || 0) !== 0 && (
+              <span style={{ fontSize: 11, color: "var(--warning)", fontFamily: "var(--font-mono)" }}>
+                Set 1 → {formatSetLabel(1, state.setNumberOffset || 0)}
+              </span>
+            )}
+          </div>
+
+          {/* Continue match button */}
+          <button className="btn btn-secondary" onClick={function() {
+            setState(function(s) {
+              var next = { ...s, matchOver: false, currentSet: s.currentSet + 1, pointsA: 0, pointsB: 0, extraSetMode: true };
+              mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { matchOver: false, currentSet: next.currentSet, pointsA: 0, pointsB: 0, extraSetMode: true }); });
+              return next;
+            });
+          }}>Continue match (+1 set)</button>
+
+          {highlightCount > 0 && (
+            <div style={{ color: 'var(--warning)', fontSize: 14, fontWeight: 600, letterSpacing: 1, marginTop: 8 }}>
+              {"\u2605"} {highlightCount} highlight{highlightCount !== 1 ? 's' : ''} marked
+            </div>
+          )}
+
+          {!state.syncTimestamp && (
+            <div className="format-info" style={{ maxWidth: 300, textAlign: "center" }}>
+              No sync point was set. SRT/FCPXML/MP4 exports require sync. CSV with wall-clock timestamps is still available.
+            </div>
+          )}
+
+          <div className="export-buttons">
+            {/* === SAFE EXPORTS FIRST === */}
+            <button className="btn btn-primary" onClick={function() { openExport("csv"); }}>Export CSV (Raw Data)</button>
+            <button className="btn btn-secondary" onClick={function() { openExport("srt"); }} disabled={!state.syncTimestamp}>Export SRT (Subtitles)</button>
+            <button className="btn btn-secondary" onClick={function() { openExport("fcpxml"); }} disabled={!state.syncTimestamp}>Export FCPXML (Final Cut)</button>
+
+            <button className="btn btn-secondary" onClick={function() { openExport("chapters"); }} disabled={!state.syncTimestamp}>Export YouTube Chapters</button>
+
+            {highlightCount > 0 && (
+              <React.Fragment>
+                <div style={{ width: "100%", borderTop: "1px solid var(--surface2)", margin: "6px 0", paddingTop: 10 }}>
+                  <div className="highlight-section-label">{"\u2605"} Highlights ({highlightCount})</div>
+                </div>
+                <button className="btn btn-secondary" onClick={function() { openExport("hlsrt"); }} disabled={!state.syncTimestamp}>Export Highlights SRT</button>
+              </React.Fragment>
+            )}
+
+            <div style={{ width: "100%", borderTop: "1px solid var(--surface2)", margin: "6px 0", paddingTop: 10 }}>
+              <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: 2, textTransform: "uppercase", color: "var(--accent)", textAlign: "center", marginBottom: 8 }}>Chroma Key Video</div>
+            </div>
+
+            {/* Match title field */}
+            <div className="title-input-wrap">
+              <label>Overlay Title</label>
+              <input
+                type="text"
+                value={state.matchTitle}
+                placeholder="e.g. U14 Girls League"
+                onChange={function(e) { var v = e.target.value; setState(function(s) { return { ...s, matchTitle: v }; }); }}
+              />
+              <span className="hint">Shown left of Set # in the overlay. Leave blank to omit.</span>
+            </div>
+
+            {/* Position toggle */}
+            <div style={{ display: "flex", alignItems: "center", gap: 10, justifyContent: "center" }}>
+              <span style={{ fontSize: 11, color: "var(--text-dim)", letterSpacing: 1 }}>POSITION:</span>
+              <div className="position-toggle">
+                <button className={overlayPositionTop ? "active" : ""} onClick={function() { setOverlayPositionTop(true); }}>&#8593; Top</button>
+                <button className={!overlayPositionTop ? "active" : ""} onClick={function() { setOverlayPositionTop(false); }}>&#8595; Bottom</button>
+              </div>
+            </div>
+
+            <button className="btn btn-success" onClick={handleGenerateMP4} disabled={!state.syncTimestamp || isEncoding}>
+              {isEncoding ? "Generating\u2026 " + encodeProgress + "%" : "Generate Overlay MP4"}
+            </button>
+            {isEncoding && (
+              <div className="progress-bar-track">
+                <div className="progress-bar-fill" style={{ width: encodeProgress + "%" }} />
+              </div>
+            )}
+
+            <div className="format-info" style={{ fontSize: 11, textAlign: "center" }}>
+              CSV is auto-downloaded first as a safety backup. If MP4 generation fails, use the Chroma Kit or import the CSV later.
+            </div>
+
+            <button className="btn btn-secondary" onClick={downloadChromaKit} disabled={!state.syncTimestamp}>&#8595; Chroma Kit (.zip fallback)</button>
+            <div style={{ display: "flex", gap: 8, width: "100%" }}>
+              <button className="btn btn-small" style={{ flex: 1 }} onClick={function() { openExport("ass"); }} disabled={!state.syncTimestamp}>View ASS</button>
+              <button className="btn btn-small" style={{ flex: 1 }} onClick={function() { openExport("chroma"); }} disabled={!state.syncTimestamp}>View Script</button>
+            </div>
+            <button className="btn btn-small" style={{ marginTop: 8 }} onClick={function() { setConfirmAction("reset"); }}>New Match</button>
+          </div>
+        </div>
+      )}
+
+      {/* ========== SPECTATOR SCREEN (Live Share) ========== */}
+      {screen === SCREEN.SPECTATOR && (
+        <SpectatorView
+          state={state}
+          liveError={liveError}
+          parentSubmitStatus={parentSubmitStatus}
+          onSubmitHighlight={handleSubmitParentHighlight}
+        />
+      )}
+
+      {/* ========== SHARE MODAL ========== */}
+      {shareModalOpen && (
+        <ShareModalView
+          state={state}
+          liveError={liveError}
+          sharePending={sharePending}
+          onClose={function() { setShareModalOpen(false); setLiveError(null); }}
+          onStart={handleStartShare}
+          onStop={handleStopShare}
+        />
+      )}
+
+      {/* ========== EXPORT MODAL ========== */}
+      {exportModal && (
+        <div className="export-modal-overlay" onClick={function() { setExportModal(null); }}>
+          <div className="export-modal" onClick={function(e) { e.stopPropagation(); }}>
+            <h3>{exportModal.filename}</h3>
+            <div className="export-preview">{exportModal.content}</div>
+            <div className="copy-feedback">{copyFeedback}</div>
+            <div className="export-actions">
+              <button className="btn btn-primary" onClick={handleCopy}>Copy to Clipboard</button>
+              <div className="format-info" style={{ fontSize: 11, textAlign: "center" }}>
+                Paste into a text editor and save as <strong>{exportModal.filename}</strong>
+              </div>
+              <button className="btn btn-small" onClick={function() { setExportModal(null); }}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ========== MP4 ERROR RECOVERY MODAL ========== */}
+      {mp4Error && (
+        <div className="error-modal-overlay" onClick={function() { setMp4Error(null); }}>
+          <div className="error-modal" onClick={function(e) { e.stopPropagation(); }}>
+            <h3>MP4 Generation Failed</h3>
+            <p>The video encoder ran into a problem. Your match data is safe. Use one of the options below:</p>
+            {mp4Error.detail && <div className="error-detail">{mp4Error.detail}</div>}
+            <div className="error-detail">{mp4Error.error}</div>
+            <div className="error-actions">
+              {state.syncTimestamp && (
+                <button className="btn btn-secondary" onClick={function() { setMp4Error(null); downloadChromaKit(); }}>&#8595; Download Chroma Kit (.zip)</button>
+              )}
+              <button className="btn btn-secondary" onClick={function() { setMp4Error(null); downloadCSV(); }}>&#8595; Download CSV</button>
+              <div className="format-info" style={{ fontSize: 11, textAlign: "center" }}>
+                You can re-generate the MP4 later by importing the CSV via the <strong>Import CSV</strong> button on the setup screen.
+              </div>
+              <button className="btn btn-small" onClick={function() { setMp4Error(null); }}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ========== CONFIRM DIALOGS ========== */}
+      {confirmAction && confirmAction !== "restore" && confirmAction !== "resync" && (
+        <div className="confirm-overlay" onClick={function() { setConfirmAction(null); }}>
+          <div className="confirm-dialog" onClick={function(e) { e.stopPropagation(); }}>
+            <h3>{confirmAction === "end" ? "End Match Early?" : "Start New Match?"}</h3>
+            <p>{confirmAction === "end" ? "This will end the match at the current score. You can still export data." : "This will discard all current match data. Make sure you've exported first."}</p>
+            <div className="confirm-actions">
+              <button className="btn btn-secondary" onClick={function() { setConfirmAction(null); }}>Cancel</button>
+              <button className="btn btn-danger" onClick={function() {
+                if (confirmAction === "end") {
+                  trackEvent('Match', 'EndEarly');
+                  setState(function(s) {
+                    var next = { ...s, matchOver: true, setHistory: s.setHistory.concat([{ winnerA: s.pointsA > s.pointsB, scoreA: s.pointsA, scoreB: s.pointsB }]) };
+                    mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { matchOver: true }); });
+                    return next;
+                  });
+                } else { resetMatch(); }
+                setConfirmAction(null);
+              }}>{confirmAction === "end" ? "End Match" : "Reset"}</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ========== RE-SYNC CONFIRM DIALOG ========== */}
+      {confirmAction === "resync" && (
+        <div className="confirm-overlay" onClick={function() { setConfirmAction(null); }}>
+          <div className="confirm-dialog" onClick={function(e) { e.stopPropagation(); }}>
+            <h3>Re-sync video alignment?</h3>
+            <p>This will rebase all logged points to the new sync moment. The original sync point will be lost. Continue?</p>
+            <div className="confirm-actions">
+              <button className="btn btn-secondary" onClick={function() { setConfirmAction(null); }}>Cancel</button>
+              <button className="btn btn-danger" onClick={function() {
+                var now = Date.now();
+                setState(function(s) {
+                  var next = { ...s, syncTimestamp: now };
+                  mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { syncTimestamp: now }); });
+                  return next;
+                });
+                autosaveState({ ...state, syncTimestamp: now });
+                setConfirmAction(null);
+              }}>Re-sync</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ========== BETA INFO MODAL ========== */}
+      {showBetaModal && (
+        <div className="beta-modal-overlay" onClick={function() { setShowBetaModal(false); }}>
+          <div className="beta-modal" onClick={function(e) { e.stopPropagation(); }}>
+            <div className="beta-modal-icon">⚡</div>
+            <div className="beta-modal-title">ScoreLayer Volley v{APP_VERSION}</div>
+            <div className="beta-modal-msg">All features are <strong>free to use</strong> during the beta phase.</div>
+            <div className="beta-modal-note">Export tools — MP4, SRT, FCPXML, YouTube Chapters and more — may require a plan after the official launch.</div>
+            <DonateBlock />
+            <button className="btn btn-primary" style={{ width: "100%", marginTop: 8 }} onClick={function() { setShowBetaModal(false); }}>Got it</button>
+          </div>
+        </div>
+      )}
+
+      {/* ========== MANUAL MODAL ========== */}
+      {showManualModal && (
+        <ManualModal onClose={function() { setShowManualModal(false); }} />
+      )}
+
+      {/* ========== DONATE PROMPT MODAL ========== */}
+      {showDonatePrompt && (
+        <DonatePromptModal onClose={function() { setShowDonatePrompt(false); }} />
+      )}
+
+      {/* ========== YOUTUBE CHAPTER VALIDATION ERRORS ========== */}
+      {ytChapterErrors && (
+        <div className="error-modal-overlay" onClick={function() { setYtChapterErrors(null); }}>
+          <div className="error-modal" onClick={function(e) { e.stopPropagation(); }}>
+            <h3>YouTube Chapter Warnings</h3>
+            <p>The generated chapter list may not work correctly on YouTube:</p>
+            <div className="error-detail" style={{ maxHeight: 120 }}>
+              {ytChapterErrors.errors.map(function(err, i) { return <div key={i}>• {err}</div>; })}
+            </div>
+            <div className="error-actions">
+              <button className="btn btn-primary" onClick={function() {
+                var info = ytChapterErrors;
+                setYtChapterErrors(null);
+                trackEvent('Export', 'Chapters');
+                setCopyFeedback("");
+                triggerExportDonate();
+                setExportModal({ type: "chapters", content: info.content, filename: info.filename });
+              }}>Download anyway</button>
+              <button className="btn btn-small" onClick={function() { setYtChapterErrors(null); }}>Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ========== RESTORE AUTOSAVE DIALOG ========== */}
+      {confirmAction === "restore" && (
+        <div className="confirm-overlay">
+          <div className="confirm-dialog">
+            <h3>Restore Match?</h3>
+            <p>A previous match was found in auto-save. Would you like to restore it or start fresh?</p>
+            <div className="confirm-actions">
+              <button className="btn btn-secondary" onClick={function() { delete window.__scorelayer_autosave; clearAutosave(); setConfirmAction(null); }}>Discard</button>
+              <button className="btn btn-primary" style={{ fontSize: 13 }} onClick={restoreAutosave}>Restore</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(React.createElement(VolleyballTracker));
+</script>
+<!-- Cloudflare Web Analytics -->
+<script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "7b35cfd2c4534994b637cf07d6d48614"}'></script>
+</body>
+</html>


### PR DESCRIPTION
- README.md: wrap Features + Usage + Live Share in <!-- MANUAL_BEGIN/END --> sentinels
- index-v3.4.html: new beta URL, prod index.html (v3.3.0) untouched
  • APP_VERSION bumped to 3.4.0-beta
  • marked@12 UMD added from jsdelivr CDN
  • DONATE_URL (Revolut) + BIZUM_PHONE placeholder constants
  • DonateBlock: shared Revolut button + Bizum tap-to-copy row
  • ManualModal: fetches README.md, slices sentinel region, renders via marked, embeds DonateBlock
  • DonatePromptModal: post-export nudge (rate-limited)
  • ? button in header → ManualModal; BETA badge → BetaModal (now embeds DonateBlock)
  • triggerExportDonate(): sessionStorage counter, fires at export #2, 7, 12, 17 …
  • Wired into: openExport, downloadChromaKit, downloadCSV, handleGenerateMP4,
    handleCSVGenerateMP4, and the YtChapterErrors 'Download anyway' path
  • All 23 tier-1 tests pass (index.html untouched, sentinels are outside EXPORTERS block)

https://claude.ai/code/session_01U5QwVG3sJVvXahmHwmJVNW