### PR TITLE
docs(manual): Live Share + MP4 overlay copy improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A mobile-first volleyball score tracker with timestamped point logging, multi-fo
 
 - **Live scoring** — Tap + / − to track points with set/match auto-detection
 - **Sync button** — Press at a known video moment (first serve or recording start) to align timestamps
-- **Live Share** — Publish the match to spectators via a QR code; parents see real-time scores and submit highlights from the stands
+- **Live Share** — Publish the match to spectators via a QR code or a link you can paste in a WhatsApp group; parents see real-time scores and submit highlights from the stands
 - **YouTube chapters** — Auto-generate a chapters file with set boundaries and highlight markers
+- **In-browser MP4 overlay** — WebCodecs generates a chroma-keyable scoreboard video right in your phone; merge it with your recording in iMovie (iPhone/Mac) or any equivalent app on Windows
 - **SRT export** — Import directly into Final Cut Pro or YouTube as captions
 - **FCPXML export** — Native Final Cut Pro timeline with positioned title clips
 - **ASS export** — Advanced SubStation Alpha subtitles with positioned score + info rows
 - **CSV export** — Full point log with wall-clock time, video offset, set/match state
-- **In-browser MP4 overlay** — WebCodecs generates a chroma-keyable scoreboard video right in your phone
 - **Chroma Key Kit** — ZIP with Python + FFmpeg fallback for desktop overlay generation
 - **PWA** — Add to Home Screen on iPhone/iPad for a native-app experience
 


### PR DESCRIPTION
## Summary

README Features section updates (feeds the in-app manual via `<!-- MANUAL_BEGIN/END -->` sentinels):

- **Live Share** — now mentions copy-pasting the link in a WhatsApp group as an alternative to the QR code
- **In-browser MP4 overlay** — moved up (right after YouTube chapters) and mentions merging with iMovie on iPhone/Mac or any equivalent app on Windows

No code changes — README is the single source of truth for the manual content.

https://claude.ai/code/session_01U5QwVG3sJVvXahmHwmJVNW

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5QwVG3sJVvXahmHwmJVNW)_