### PR TITLE
release: promote v3.4.0-beta to main index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Single `index.html` file — React 18 + Babel Standalone (CDN), `mp4-muxer` ES m
 
 | Version | What shipped |
 |---|---|
+| **v3.4.0-beta** | In-app manual (`?` button → fetches README, renders Features + Usage + Live Share via marked), donate plumbing (Revolut button in BETA modal, manual, and post-export nudge), blue `?` / donate label styling, README manual sentinels (closes #42, #43, #45) |
 | **v3.3.0-beta** | New SL-on-volleyball app icon (SVG + 192/512 PNG), refreshed README, version bump |
 | **v3.2.0-beta** | Spectator previous-sets panel, parent highlight tag chips + `★ Quick` one-tap submit, score snapshot at submission time, parent highlights merged into in-video overlay, Firebase rules extended for the new fields (#39, closes #36) |
 | **v3.1.0-beta** | Tappable scorekeeper highlight notes in the match log, MP4 overlay preserves pre-rally score when a highlight spans two entries, beta info modal shows `APP_VERSION` (#35) |

--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
 <script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.13.2/firebase-database-compat.js"></script>
+<!-- marked: Markdown renderer for the in-app manual. UMD build exposes window.marked. -->
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
 <style>
 html, body { margin: 0; padding: 0; background: #0a0e14; }
   * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -59,7 +61,41 @@ html, body { margin: 0; padding: 0; background: #0a0e14; }
   .beta-modal-icon { font-size: 36px; margin-bottom: 12px; }
   .beta-modal-title { font-size: 16px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; margin-bottom: 16px; background: linear-gradient(135deg, #f59e0b, #fcd34d); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
   .beta-modal-msg { font-size: 14px; color: var(--text); line-height: 1.7; margin-bottom: 8px; }
-  .beta-modal-note { font-size: 12px; color: var(--text-dim); line-height: 1.6; margin-bottom: 24px; font-family: var(--font-mono); border-top: 1px solid var(--surface2); padding-top: 12px; margin-top: 12px; }
+  .beta-modal-note { font-size: 12px; color: var(--text-dim); line-height: 1.6; margin-bottom: 16px; font-family: var(--font-mono); border-top: 1px solid var(--surface2); padding-top: 12px; margin-top: 12px; }
+  /* --- Donate block (shared across BetaModal, ManualModal, DonatePromptModal) --- */
+  .donate-block { display: flex; flex-direction: column; gap: 10px; margin: 12px 0 0; }
+  .donate-label { font-size: 10px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: #00b4d8; text-align: center; }
+  .btn-donate-revolut { display: block; text-decoration: none; text-align: center; background: linear-gradient(135deg, #00b4d8, #0077b6); color: #fff; padding: 13px 20px; font-size: 13px; font-weight: 700; letter-spacing: 1.5px; border-radius: 10px; box-shadow: 0 4px 16px rgba(0,119,182,0.35); font-family: var(--font-display); text-transform: uppercase; transition: all 0.15s; }
+  .btn-donate-revolut:active { transform: scale(0.97); }
+
+  /* --- Manual button in header --- */
+  .manual-btn { background: none; border: 1px solid #00b4d8; color: #00b4d8; border-radius: 6px; padding: 3px 9px; font-size: 12px; font-weight: 700; cursor: pointer; font-family: var(--font-display); line-height: 1; -webkit-tap-highlight-color: transparent; }
+  .manual-btn:active { background: rgba(0,180,216,0.12); }
+  /* --- Manual modal --- */
+  .manual-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.85); z-index: 200; display: flex; align-items: flex-end; justify-content: center; }
+  .manual-dialog { background: var(--surface); border-radius: 20px 20px 0 0; width: 100%; max-width: 480px; max-height: 90dvh; display: flex; flex-direction: column; }
+  .manual-header { display: flex; align-items: center; justify-content: space-between; padding: 18px 20px 12px; border-bottom: 1px solid var(--surface2); flex-shrink: 0; }
+  .manual-title { font-size: 13px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); }
+  .manual-body { flex: 1; overflow-y: auto; padding: 20px; -webkit-overflow-scrolling: touch; }
+  .manual-loading { color: var(--text-dim); text-align: center; padding: 32px; font-size: 13px; }
+  .manual-error { color: var(--team-b); text-align: center; padding: 16px; font-size: 13px; }
+  .manual-donate-section { margin-top: 24px; border-top: 1px solid var(--surface2); padding-top: 16px; }
+  .manual-footer { padding: 12px 20px calc(24px + env(safe-area-inset-bottom, 0px)); flex-shrink: 0; border-top: 1px solid var(--surface2); }
+  /* Markdown content inside manual */
+  .manual-content h2 { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--accent); margin: 20px 0 8px; }
+  .manual-content h2:first-child { margin-top: 0; }
+  .manual-content p { font-size: 13px; color: var(--text); line-height: 1.7; margin: 0 0 10px; font-weight: 400; }
+  .manual-content ul, .manual-content ol { padding-left: 18px; margin: 0 0 10px; }
+  .manual-content li { font-size: 13px; color: var(--text); line-height: 1.7; font-weight: 400; }
+  .manual-content strong { font-weight: 700; color: var(--text); }
+  .manual-content code { font-family: var(--font-mono); font-size: 11px; background: var(--surface2); padding: 1px 5px; border-radius: 3px; }
+  .manual-content a { color: var(--accent); text-decoration: none; }
+  /* --- Donate prompt modal (post-export) --- */
+  .donate-prompt-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.78); z-index: 300; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .donate-prompt-dialog { background: var(--surface); border-radius: 16px; padding: 28px 20px 20px; max-width: 320px; width: 100%; border: 1px solid rgba(255,107,43,0.25); box-shadow: 0 0 40px rgba(255,107,43,0.1), 0 8px 32px rgba(0,0,0,0.5); text-align: center; }
+  .donate-prompt-icon { font-size: 32px; margin-bottom: 8px; }
+  .donate-prompt-title { font-size: 15px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; margin-bottom: 10px; color: var(--text); }
+  .donate-prompt-msg { font-size: 13px; color: var(--text-dim); line-height: 1.65; margin-bottom: 4px; font-weight: 400; }
   .setup { flex: 1; display: flex; flex-direction: column; justify-content: center; padding: 32px 24px; gap: 28px; }
   .setup-title { font-size: 28px; font-weight: 700; text-transform: uppercase; letter-spacing: 2px; text-align: center; background: linear-gradient(135deg, var(--accent), #ff9a5c); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
   .setup-subtitle { text-align: center; color: var(--text-dim); font-size: 13px; font-weight: 400; letter-spacing: 1px; margin-top: -16px; }
@@ -254,7 +290,8 @@ var SETS_TO_WIN_MATCH = 3;
 var MIN_LEAD = 2;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
-var APP_VERSION = "3.3.0-beta";
+var APP_VERSION = "3.4.0-beta";
+var DONATE_URL = "https://revolut.me/jpasotto";
 
 // --- Live Share (Firebase RTDB) ---
 // Web client config for the scorelayer-volley Firebase project. The apiKey is
@@ -2357,6 +2394,119 @@ var sync = (function() {
 <script type="text/babel">
 const { useState, useRef, useCallback, useEffect, useMemo } = React;
 
+// ─── DonateBlock ───────────────────────────────────────────────────────────
+// Shared donate UI reused in BetaModal, ManualModal, DonatePromptModal.
+function DonateBlock() {
+  return (
+    <div className="donate-block">
+      <div className="donate-label">Saved some court-side editing time?</div>
+      <a className="btn-donate-revolut" href={DONATE_URL} target="_blank" rel="noopener noreferrer">
+        ☕ Buy me a coffee break — 5€ is plenty
+      </a>
+    </div>
+  );
+}
+
+// ─── ManualModal ───────────────────────────────────────────────────────────
+// Fetches ./README.md, slices the <!-- MANUAL_BEGIN --> … <!-- MANUAL_END -->
+// region, renders via marked, and embeds a DonateBlock at the bottom.
+function ManualModal(props) {
+  const [content, setContent] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState(null);
+
+  useEffect(function() {
+    fetch("./README.md")
+      .then(function(r) {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        return r.text();
+      })
+      .then(function(text) {
+        var BEGIN = "<!-- MANUAL_BEGIN -->";
+        var END = "<!-- MANUAL_END -->";
+        var s = text.indexOf(BEGIN);
+        var e = text.indexOf(END);
+        var slice = (s !== -1 && e !== -1)
+          ? text.slice(s + BEGIN.length, e).trim()
+          : text;
+        setContent(slice);
+        setLoading(false);
+      })
+      .catch(function(err) {
+        setFetchError("Could not load manual. Check your connection.");
+        setLoading(false);
+      });
+  }, []);
+
+  // Split rendered HTML at the ## Usage heading so DonateBlock can be
+  // inserted between the Features list and the Usage/Live Share sections.
+  var htmlParts = { before: "", after: "" };
+  if (!loading && !fetchError && typeof marked !== "undefined") {
+    var full = marked.parse(content);
+    // marked renders ## Usage as <h2 ...>Usage</h2> — find that boundary.
+    var splitIdx = full.search(/<h2[^>]*>\s*Usage\s*<\/h2>/i);
+    if (splitIdx !== -1) {
+      htmlParts.before = full.slice(0, splitIdx);
+      htmlParts.after  = full.slice(splitIdx);
+    } else {
+      htmlParts.before = full;
+    }
+  }
+
+  return (
+    <div className="manual-overlay" onClick={props.onClose}>
+      <div className="manual-dialog" onClick={function(e) { e.stopPropagation(); }}>
+        <div className="manual-header">
+          <div className="manual-title">📖 ScoreLayer Volley v{APP_VERSION} Manual</div>
+          <button className="manual-btn" onClick={props.onClose}>✕</button>
+        </div>
+        <div className="manual-body">
+          {loading && <div className="manual-loading">Loading manual…</div>}
+          {fetchError && <div className="manual-error">{fetchError}</div>}
+          {!loading && !fetchError && (
+            <>
+              <div className="manual-content" dangerouslySetInnerHTML={{ __html: htmlParts.before }} />
+              <div className="manual-donate-section">
+                <DonateBlock />
+              </div>
+              {htmlParts.after && (
+                <div className="manual-content" dangerouslySetInnerHTML={{ __html: htmlParts.after }} />
+              )}
+            </>
+          )}
+          <div className="manual-donate-section">
+            <DonateBlock />
+          </div>
+        </div>
+        <div className="manual-footer">
+          <button className="btn btn-primary" style={{ width: "100%" }} onClick={props.onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── DonatePromptModal ─────────────────────────────────────────────────────
+// Rate-limited post-export nudge. Fires at the 2nd export of the session,
+// then every 5 thereafter (2, 7, 12, 17 …).
+function DonatePromptModal(props) {
+  return (
+    <div className="donate-prompt-overlay" onClick={props.onClose}>
+      <div className="donate-prompt-dialog" onClick={function(e) { e.stopPropagation(); }}>
+        <div className="donate-prompt-icon">⚡</div>
+        <div className="donate-prompt-title">Enjoying ScoreLayer?</div>
+        <div className="donate-prompt-msg">
+          All features are free during beta. If this app saves you time at the court, consider buying me a coffee — it helps keep the project going.
+        </div>
+        <DonateBlock />
+        <button className="btn btn-small" style={{ marginTop: 14, width: "100%" }} onClick={props.onClose}>
+          Maybe later
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function SpectatorView(props) {
   const state = props.state;
   const [name, setName] = useState(state.parentName || "");
@@ -2689,6 +2839,12 @@ function VolleyballTracker() {
 
   // Beta info modal
   const [showBetaModal, setShowBetaModal] = useState(false);
+
+  // Manual modal
+  const [showManualModal, setShowManualModal] = useState(false);
+
+  // Donate prompt (post-export nudge)
+  const [showDonatePrompt, setShowDonatePrompt] = useState(false);
 
   // YouTube chapter validation errors modal
   const [ytChapterErrors, setYtChapterErrors] = useState(null);
@@ -3091,6 +3247,17 @@ function VolleyballTracker() {
     }
   }
 
+  // --- Export donate nudge ---
+  // Increments a sessionStorage counter and opens DonatePromptModal at 2, 7, 12, 17 …
+  function triggerExportDonate() {
+    var key = "scorelayer_export_count";
+    var count = parseInt(sessionStorage.getItem(key) || "0", 10) + 1;
+    sessionStorage.setItem(key, String(count));
+    if (count === 2 || (count > 2 && (count - 2) % 5 === 0)) {
+      setShowDonatePrompt(true);
+    }
+  }
+
   // --- Export functions ---
   function openExport(type) {
     var content = "";
@@ -3134,6 +3301,7 @@ function VolleyballTracker() {
     var exportEventMap = { srt: 'SRT', fcpxml: 'FCPXML', ass: 'ASS', chroma: 'ChromaScript', chapters: 'Chapters', hlsrt: 'HlSRT', csv: 'CSV' };
     if (exportEventMap[type]) trackEvent('Export', exportEventMap[type]);
     setCopyFeedback("");
+    triggerExportDonate();
     setExportModal({ type: type, content: content, filename: fname });
   }
 
@@ -3153,6 +3321,7 @@ function VolleyballTracker() {
     var blob = new Blob([zipBytes], { type: "application/zip" });
     var zipFilename = fname + "_chroma_kit.zip";
     shareOrDownload(blob, zipFilename, "application/zip");
+    triggerExportDonate();
   }
 
   function downloadCSV() {
@@ -3161,6 +3330,7 @@ function VolleyballTracker() {
     var fname = "scorelayer_" + state.teamA + "_vs_" + state.teamB + ".csv";
     var blob = new Blob([content], { type: "text/csv" });
     shareOrDownload(blob, fname, "text/csv");
+    triggerExportDonate();
   }
 
   async function handleGenerateMP4() {
@@ -3187,6 +3357,7 @@ function VolleyballTracker() {
       setEncodeProgress(100);
       trackEvent('Export', 'MP4Success');
       shareOrDownload(result.blob, result.filename, "video/mp4");
+      triggerExportDonate();
     } else {
       setMp4Error(result);
     }
@@ -3241,6 +3412,7 @@ function VolleyballTracker() {
       setCsvEncodeProgress(100);
       trackEvent('Export', 'MP4Success');
       shareOrDownload(result.blob, result.filename, "video/mp4");
+      triggerExportDonate();
     } else {
       setMp4Error(result);
     }
@@ -3286,6 +3458,7 @@ function VolleyballTracker() {
         </h1>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           {screen === SCREEN.MATCH && !state.matchOver && <div className="live-dot" />}
+          <button className="manual-btn" title="User Manual" onClick={function() { setShowManualModal(true); }}>?</button>
           {screen === SCREEN.SETUP && (
             <button className="btn btn-small" onClick={function() { setScreen(SCREEN.CSV_IMPORT); }} style={{ fontSize: 10 }}>Import CSV</button>
           )}
@@ -3885,9 +4058,20 @@ function VolleyballTracker() {
             <div className="beta-modal-title">ScoreLayer Volley v{APP_VERSION}</div>
             <div className="beta-modal-msg">All features are <strong>free to use</strong> during the beta phase.</div>
             <div className="beta-modal-note">Export tools — MP4, SRT, FCPXML, YouTube Chapters and more — may require a plan after the official launch.</div>
-            <button className="btn btn-primary" style={{ width: "100%" }} onClick={function() { setShowBetaModal(false); }}>Got it</button>
+            <DonateBlock />
+            <button className="btn btn-primary" style={{ width: "100%", marginTop: 8 }} onClick={function() { setShowBetaModal(false); }}>Got it</button>
           </div>
         </div>
+      )}
+
+      {/* ========== MANUAL MODAL ========== */}
+      {showManualModal && (
+        <ManualModal onClose={function() { setShowManualModal(false); }} />
+      )}
+
+      {/* ========== DONATE PROMPT MODAL ========== */}
+      {showDonatePrompt && (
+        <DonatePromptModal onClose={function() { setShowDonatePrompt(false); }} />
       )}
 
       {/* ========== YOUTUBE CHAPTER VALIDATION ERRORS ========== */}
@@ -3905,6 +4089,7 @@ function VolleyballTracker() {
                 setYtChapterErrors(null);
                 trackEvent('Export', 'Chapters');
                 setCopyFeedback("");
+                triggerExportDonate();
                 setExportModal({ type: "chapters", content: info.content, filename: info.filename });
               }}>Download anyway</button>
               <button className="btn btn-small" onClick={function() { setYtChapterErrors(null); }}>Cancel</button>


### PR DESCRIPTION
## Summary

Promotes `index-v3.4.html` → `index.html`, replacing v3.3.0-beta as the production app.

- `index.html` is now **v3.4.0-beta**
- `index-v3.4.html` remains at the repo root as the dedicated beta URL (same pattern as `index-v3.html`)
- README releases table updated with the v3.4.0-beta entry

## What's in v3.4.0-beta (already tested via the beta URL)

- `?` button in header → in-app manual (fetches README, renders Features + Usage + Live Share via `marked`)
- Donate block: "☕ Buy me a coffee break — 5€ is plenty" → `revolut.me/jpasotto`, shown in BETA modal, manual, and post-export nudge
- Post-export donate prompt: fires at export #2, then every 5 (sessionStorage counter)
- Blue `#00b4d8` styling on `?` button and donate label
- DonateBlock appears twice in the manual (after Features, and again at the very end)
- README manual sentinels (`<!-- MANUAL_BEGIN/END -->`)
- Live Share feature description mentions WhatsApp link sharing
- In-browser MP4 overlay moved up in the features list, mentions iMovie / Windows merge

Closes #45, #42, #43.

## Test plan
- [ ] Production URL loads v3.4.0-beta (`BETA` badge shows v3.4.0-beta)
- [ ] `?` button visible in blue, opens manual modal
- [ ] Manual shows Features → DonateBlock → Usage → Live Share → DonateBlock → CLOSE
- [ ] BETA badge modal shows donate button
- [ ] Donate prompt fires after 2nd export
- [ ] `index-v3.4.html` still works as the beta URL
- [ ] All 23 tier-1 tests pass

https://claude.ai/code/session_01U5QwVG3sJVvXahmHwmJVNW

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5QwVG3sJVvXahmHwmJVNW)_