### PR TITLE
Fix #51: cap highlight star to a short tail; fix set-1 chapter offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,10 @@ var POINTS_TO_WIN_SET = 25;
 var POINTS_TO_WIN_TIEBREAK = 15;
 var SETS_TO_WIN_MATCH = 3;
 var MIN_LEAD = 2;
+// ★ overlay star stays lit this long (seconds) after a new score appears, then
+// the same score keeps displaying unlit. Caps the highlight to a short tail so
+// it no longer bleeds across the following point (issue #51).
+var OVERLAY_STAR_SEC = 5;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
 var APP_VERSION = "3.4.0-beta";
@@ -756,14 +760,18 @@ function buildYouTubeChapterList(pointLog, syncTimestamp, teamA, teamB, setNumbe
   // Add highlight chapters — skip if timestamp coincides with a set boundary
   var setFirstMsValues = {};
   for (var setKey in setFirstMs) { setFirstMsValues[setFirstMs[setKey]] = true; }
+  // When Set 1 was rounded to 0:00, treat 0 as an occupied boundary so a
+  // first-point highlight collapsed to 0 is skipped rather than duplicated.
+  if (set1AtZero) setFirstMsValues[0] = true;
   for (var k = 0; k < pointLog.length; k++) {
     var ph = pointLog[k];
     if (!ph.highlight) continue;
     var offsetMs = ph.timestamp - syncTimestamp;
     if (offsetMs < 0) continue;
-    // When a highlight is the first point of a set, it coincides with the set boundary chapter.
-    // Skip the highlight chapter to avoid duplicate timestamps that break ascending order.
-    var effectiveMs = (set1AtZero && ph.setNum === 1) ? 0 : offsetMs;
+    // Only collapse to 0:00 the set-1 highlight that actually coincides with the
+    // rounded-to-zero set start (offset <= 1s). A later set-1 highlight must keep
+    // its real offset (issue #51 — it was wrongly pinned to 0:00).
+    var effectiveMs = (set1AtZero && ph.setNum === 1 && offsetMs <= 1000) ? 0 : offsetMs;
     if (setFirstMsValues[effectiveMs]) continue;
     var hlText = "\u2605 " + teamA + " " + ph.pointsA + "-" + ph.pointsB + " " + teamB + " (" + formatSetLabel(ph.setNum, setNumberOffset) + ")";
     if (ph.highlightNote) hlText += " [" + ph.highlightNote + "]";
@@ -961,17 +969,42 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, 
     } else {
       var isSetBreak = i < pointLog.length - 1 && pointLog[i + 1].setNum !== p.setNum;
       endSec = isSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
-      entries.push({
-        type: 'score',
-        start: Math.round(startSec * 1000) / 1000,
-        end:   Math.round(endSec   * 1000) / 1000,
-        score:      teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB,
-        set_info:   formatSetLabel(p.setNum, setNumberOffset),
-        title:      title,
-        sets_score: 'Sets ' + setsA + ':' + setsB,
-        highlight: p.highlight || false,
-        highlightNote: p.highlightNote || null
-      });
+      var scoreText = teamA + '  ' + p.pointsA + ' : ' + p.pointsB + '  ' + teamB;
+      var setInfo   = formatSetLabel(p.setNum, setNumberOffset);
+      var setsScore = 'Sets ' + setsA + ':' + setsB;
+      var isHighlighted = p.highlight || false;
+      var hlNote = p.highlightNote || null;
+      // Cap the ★ to a short tail: when a highlighted point's own score entry
+      // would run longer than OVERLAY_STAR_SEC, split it into a lit head and an
+      // unlit tail so the star disappears while the same score keeps showing
+      // (issue #51). The previous (rally) entry stays fully lit via the
+      // back-propagation above.
+      if (isHighlighted && (endSec - startSec) > OVERLAY_STAR_SEC) {
+        var splitSec = startSec + OVERLAY_STAR_SEC;
+        entries.push({
+          type: 'score',
+          start: Math.round(startSec * 1000) / 1000,
+          end:   Math.round(splitSec * 1000) / 1000,
+          score: scoreText, set_info: setInfo, title: title, sets_score: setsScore,
+          highlight: true, highlightNote: hlNote
+        });
+        entries.push({
+          type: 'score',
+          start: Math.round(splitSec * 1000) / 1000,
+          end:   Math.round(endSec   * 1000) / 1000,
+          score: scoreText, set_info: setInfo, title: title, sets_score: setsScore,
+          highlight: false, highlightNote: null
+        });
+      } else {
+        entries.push({
+          type: 'score',
+          start: Math.round(startSec * 1000) / 1000,
+          end:   Math.round(endSec   * 1000) / 1000,
+          score: scoreText, set_info: setInfo, title: title, sets_score: setsScore,
+          highlight: isHighlighted,
+          highlightNote: hlNote
+        });
+      }
       if (isSetBreak) {
         entries.push({
           start: Math.round(endSec * 1000) / 1000,
@@ -992,11 +1025,11 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, 
       if (typeof h.clientTimestamp !== "number") continue;
       var tSec = (h.clientTimestamp - syncTimestamp) / 1000;
       if (tSec < 0) continue;
-      var target = null;
+      var target = null, targetIdx = -1;
       for (var k = 0; k < entries.length; k++) {
         var e = entries[k];
         if (e.blank || e.type !== "score") continue;
-        if (tSec >= e.start && tSec < e.end) { target = e; break; }
+        if (tSec >= e.start && tSec < e.end) { target = e; targetIdx = k; break; }
       }
       if (!target) continue;
       var parentBlurb = [
@@ -1005,10 +1038,32 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, 
         h.note || null
       ].filter(Boolean).join(" · ");
       if (!parentBlurb) parentBlurb = "Parent highlight";
-      target.highlight = true;
-      target.highlightNote = target.highlightNote
-        ? target.highlightNote + " + " + parentBlurb
-        : parentBlurb;
+      if (target.highlight) {
+        // Already lit (scorekeeper ★ or an earlier parent) — just append the
+        // note; leave the existing timing/split alone.
+        target.highlightNote = target.highlightNote
+          ? target.highlightNote + " + " + parentBlurb
+          : parentBlurb;
+      } else if ((target.end - target.start) > OVERLAY_STAR_SEC) {
+        // Cap the parent star to the same short tail (issue #51): shrink the
+        // matched entry to a lit head and insert an unlit tail after it.
+        var pOrigEnd = target.end;
+        var pSplit = Math.round((target.start + OVERLAY_STAR_SEC) * 1000) / 1000;
+        target.end = pSplit;
+        target.highlight = true;
+        target.highlightNote = parentBlurb;
+        entries.splice(targetIdx + 1, 0, {
+          type: 'score',
+          start: pSplit,
+          end:   pOrigEnd,
+          score: target.score, set_info: target.set_info,
+          title: target.title, sets_score: target.sets_score,
+          highlight: false, highlightNote: null
+        });
+      } else {
+        target.highlight = true;
+        target.highlightNote = parentBlurb;
+      }
     }
   }
 

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -72,6 +72,38 @@ test("buildYouTubeChapterList: realistic match passes validateYouTubeChapters", 
   assert.equal(result.errors.length, 0);
 });
 
+test("buildYouTubeChapterList: #51 — later set-1 highlight keeps its true offset when set 1 starts at 0:00", () => {
+  const sync = 1700000000000;
+  const log = [
+    // Set 1 first point within 1s of sync → set1AtZero = true
+    { timestamp: sync + 800,   setNum: 1, pointsA: 1, pointsB: 0, highlight: false, highlightNote: null },
+    // Mid-set highlight ~16s in → must NOT collapse to 0:00 (the original bug)
+    { timestamp: sync + 16159, setNum: 1, pointsA: 2, pointsB: 0, highlight: true,  highlightNote: "Great spike" },
+    { timestamp: sync + 30000, setNum: 1, pointsA: 3, pointsB: 0, highlight: false, highlightNote: null },
+  ];
+  const out = helpers.buildYouTubeChapterList(log, sync, "Home", "Away", 0, []);
+  const hl = out.find((c) => c.text.includes("Great spike"));
+  assert.ok(hl, "expected the mid-set highlight chapter");
+  assert.equal(hl.timeMs, 16159, "later set-1 highlight must keep its true offset, not 0:00");
+  // Only the "Set 1 Start" chapter belongs at 0:00.
+  assert.equal(out.filter((c) => c.timeMs === 0).length, 1, "no spurious 0:00 highlight chapter");
+  for (let i = 1; i < out.length; i++) {
+    assert.ok(out[i].timeMs > out[i - 1].timeMs, "chapters strictly ascending");
+  }
+});
+
+test("buildYouTubeChapterList: #51 — first-point set-1 highlight does not create a duplicate 0:00 chapter", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 500,   setNum: 1, pointsA: 1, pointsB: 0, highlight: true,  highlightNote: "Opening ace" },
+    { timestamp: sync + 30000, setNum: 1, pointsA: 2, pointsB: 0, highlight: false, highlightNote: null },
+  ];
+  const out = helpers.buildYouTubeChapterList(log, sync, "Home", "Away", 0, []);
+  const atZero = out.filter((c) => c.timeMs === 0);
+  assert.equal(atZero.length, 1, "only the Set 1 Start chapter should sit at 0:00");
+  assert.equal(atZero[0].text, "Set 1 Start", "the single 0:00 chapter is the set start, not the highlight");
+});
+
 // ---------- generateCSV ----------
 
 test("generateCSV: each point produces one row with the documented columns", () => {
@@ -261,10 +293,13 @@ test("buildOverlayEntries: parent highlight on a scorekeeper-starred entry appen
     { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: true,  highlightNote: "Great spike" },
     { timestamp: sync + 300000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
   ];
-  const ph = [{ clientTimestamp: sync + 250000, name: "Alice", note: "agreed", deleted: false }];
+  // Parent presses within the scorekeeper star window (issue #51 caps the ★ to
+  // OVERLAY_STAR_SEC after the score appears at +200s), so this is genuine
+  // agreement on the same moment and must append rather than overwrite.
+  const ph = [{ clientTimestamp: sync + 202000, name: "Alice", note: "agreed", deleted: false }];
   const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
-  const target = entries.find(e => e.type === "score" && e.score && e.score.includes("2 : 0"));
-  assert.ok(target, "expected score 2 : 0 entry");
+  const target = entries.find(e => e.type === "score" && e.score && e.score.includes("2 : 0") && e.highlight);
+  assert.ok(target, "expected highlighted score 2 : 0 entry");
   assert.ok(target.highlightNote.includes("Great spike"), "original scorekeeper note must be preserved");
   assert.ok(target.highlightNote.includes("Alice"), "parent name must be appended");
   assert.ok(target.highlightNote.includes(" + "), "join must use ' + ' delimiter");
@@ -298,6 +333,62 @@ test("buildOverlayEntries: set-boundary guard — highlight on first point of se
   assert.ok(set1Entries.length > 0, "expected at least one set-1 score entry");
   const lastSet1 = set1Entries[set1Entries.length - 1];
   assert.equal(lastSet1.highlight, false, "last set-1 entry must keep highlight: false (cross-set propagation blocked)");
+});
+
+test("buildOverlayEntries: #51 — highlighted score entry splits into lit head (~5s) + unlit tail", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 4000,  setNum: 1, pointsA: 9,  pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 16000, setNum: 1, pointsA: 10, pointsB: 0, setsA: 0, setsB: 0, highlight: true,  highlightNote: "Great spike" },
+    { timestamp: sync + 28000, setNum: 1, pointsA: 11, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0);
+  entries.forEach((e, i) => assert.ok(e.end > e.start, `entry ${i} collapsed`));
+
+  const tenZero = entries.filter((e) => e.type === "score" && e.score && e.score.includes("10 : 0"));
+  assert.equal(tenZero.length, 2, "highlighted 10:0 score should split into lit head + unlit tail");
+  const head = tenZero[0], tail = tenZero[1];
+  assert.equal(head.highlight, true, "head is lit");
+  assert.equal(tail.highlight, false, "tail is unlit");
+  assert.equal(head.highlightNote, "Great spike");
+  assert.equal(tail.highlightNote, null);
+  assert.ok(Math.abs((head.end - head.start) - helpers.OVERLAY_STAR_SEC) < 0.001, "head ≈ OVERLAY_STAR_SEC long");
+  assert.equal(head.end, tail.start, "head and tail must be contiguous");
+  // The rally (9:0) entry stays fully lit via #35 back-propagation
+  const nineZero = entries.find((e) => e.type === "score" && e.score && e.score.includes("9 : 0"));
+  assert.equal(nineZero.highlight, true, "rally entry stays lit");
+});
+
+test("buildOverlayEntries: #51 — short highlighted entry (<= star window) stays a single lit entry", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 4000, setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 8000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: true,  highlightNote: "Quick" },
+    { timestamp: sync + 11000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0);
+  const twoZero = entries.filter((e) => e.type === "score" && e.score && e.score.includes("2 : 0"));
+  assert.equal(twoZero.length, 1, "short highlighted entry must not split");
+  assert.equal(twoZero[0].highlight, true);
+});
+
+test("buildOverlayEntries: #51 — parent highlight on a long entry produces lit head + unlit tail", () => {
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 4000,  setNum: 1, pointsA: 1, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 16000, setNum: 1, pointsA: 2, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 40000, setNum: 1, pointsA: 3, pointsB: 0, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  const ph = [{ clientTimestamp: sync + 18000, name: "Alice", note: "Big rally", deleted: false }];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
+  entries.forEach((e, i) => assert.ok(e.end > e.start, `entry ${i} collapsed`));
+  const twoZero = entries.filter((e) => e.type === "score" && e.score && e.score.includes("2 : 0"));
+  assert.equal(twoZero.length, 2, "parent-marked long entry should split into head + tail");
+  assert.equal(twoZero[0].highlight, true, "head is lit");
+  assert.ok(twoZero[0].highlightNote.includes("Alice"), "head note includes parent name");
+  assert.ok(Math.abs((twoZero[0].end - twoZero[0].start) - helpers.OVERLAY_STAR_SEC) < 0.001, "head ≈ OVERLAY_STAR_SEC long");
+  assert.equal(twoZero[1].highlight, false, "tail is unlit");
+  assert.equal(twoZero[0].end, twoZero[1].start, "head and tail must be contiguous");
 });
 
 // ---------- helpers ----------


### PR DESCRIPTION
Fixes #51. Two distinct bugs surfaced by the issue's overlay video + exports.

## Bug 1 — Overlay ★ lasted 2 points
In `buildOverlayEntries`, a highlighted point's own score entry ran until the *next* point's timestamp while carrying `highlight=true`. Combined with the existing #35 back-propagation (which correctly lights the previous "rally" entry), the star stayed visible across two full points (e.g. 0-9→0-10 **and** 0-10→0-11).

**Fix:** added `OVERLAY_STAR_SEC = 5`. A highlighted point's entry now splits into a **lit head** (~5s after the new score appears) plus an **unlit tail** that keeps showing the same score, so the star disappears after a short celebration while the rally entry stays fully lit. The same cap is applied to parent-submitted highlights.

## Bug 2 — Set-1 highlights collapsed to 0:00 in YouTube chapters
In `buildYouTubeChapterList`, when set 1's first point fell within 1s of sync, `(set1AtZero && ph.setNum === 1)` forced **every** set-1 highlight to `0:00` — exactly why the issue's 0-10 highlight showed at `0:00` instead of ~`0:16`.

**Fix:** tightened the condition to `&& offsetMs <= 1000` so only the highlight coinciding with the rounded-to-zero set start collapses; later set-1 highlights keep their real offset. Added a guard against a duplicate 0:00 chapter.

CSV export was already correct — no change.

## Tests
Added 5 regression tests (2 chapter, 3 overlay) reproducing the issue scenario. One pre-existing parent-highlight test had its press time moved into the star window (it previously relied on the whole-entry star). Full suite: **28/28 passing** locally via `node --test tests/*.test.mjs`.

https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD)_