### PR TITLE
Back-propagate spectator highlight ★ to the rally entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -1038,6 +1038,22 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, 
         h.note || null
       ].filter(Boolean).join(" · ");
       if (!parentBlurb) parentBlurb = "Parent highlight";
+      // Back-propagate the ★ to the rally entry — the previous point's score in
+      // the same set — mirroring the scorekeeper highlight behavior above, so a
+      // spectator highlight also marks the play that produced the score (not just
+      // the 5s after it). Skip blanks, non-score entries, and split siblings of
+      // the matched point (same score string).
+      var rallyIdx = targetIdx - 1;
+      while (rallyIdx >= 0 && (entries[rallyIdx].blank || entries[rallyIdx].type !== 'score' || entries[rallyIdx].score === target.score)) {
+        rallyIdx--;
+      }
+      if (rallyIdx >= 0 && entries[rallyIdx].set_info === target.set_info) {
+        var rally = entries[rallyIdx];
+        rally.highlight = true;
+        rally.highlightNote = rally.highlightNote
+          ? rally.highlightNote + " + " + parentBlurb
+          : parentBlurb;
+      }
       if (target.highlight) {
         // Already lit (scorekeeper ★ or an earlier parent) — just append the
         // note; leave the existing timing/split alone.

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -391,6 +391,38 @@ test("buildOverlayEntries: #51 — parent highlight on a long entry produces lit
   assert.equal(twoZero[0].end, twoZero[1].start, "head and tail must be contiguous");
 });
 
+test("buildOverlayEntries: spectator highlight back-propagates the ★ to the rally (previous) entry", () => {
+  // Mirrors the scorekeeper behavior: a parent who taps just after the score
+  // appears should also light the play that produced it (the previous point's
+  // entry), not only the 5s tail on the new score.
+  const sync = 1700000000000;
+  const log = [
+    { timestamp: sync + 4000,  setNum: 1, pointsA: 0, pointsB: 18, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 16000, setNum: 1, pointsA: 0, pointsB: 19, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 40000, setNum: 1, pointsA: 0, pointsB: 20, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+    { timestamp: sync + 52000, setNum: 1, pointsA: 0, pointsB: 21, setsA: 0, setsB: 0, highlight: false, highlightNote: null },
+  ];
+  // Parent taps just after 0-20 appears (entry window [40s, 52s]).
+  const ph = [{ clientTimestamp: sync + 42000, name: "Dad", note: "Nice dig", deleted: false }];
+  const entries = helpers.buildOverlayEntries(log, sync, "Home", "Away", "Test", 0, ph);
+  entries.forEach((e, i) => assert.ok(e.end > e.start, `entry ${i} collapsed`));
+
+  // Rally entry (0-19) — the play that produced 0-20 — must be lit for its full duration.
+  const rally = entries.filter((e) => e.type === "score" && e.score && e.score.includes("0 : 19"));
+  assert.equal(rally.length, 1, "rally entry must not be split");
+  assert.equal(rally[0].highlight, true, "rally (0-19) entry must be lit via back-propagation");
+  assert.ok(rally[0].highlightNote && rally[0].highlightNote.includes("Dad"), "rally note carries the parent blurb");
+
+  // Matched entry (0-20) gets the capped 5s lit head.
+  const twentyHead = entries.find((e) => e.type === "score" && e.score && e.score.includes("0 : 20") && e.highlight);
+  assert.ok(twentyHead, "0-20 entry should have a lit head");
+  assert.ok(Math.abs((twentyHead.end - twentyHead.start) - helpers.OVERLAY_STAR_SEC) < 0.001, "head ≈ OVERLAY_STAR_SEC long");
+
+  // The earlier point (0-18) must stay unlit.
+  const eighteen = entries.find((e) => e.type === "score" && e.score && e.score.includes("0 : 18"));
+  assert.equal(eighteen.highlight, false, "points before the rally stay unlit");
+});
+
 // ---------- helpers ----------
 
 function parseSrtTime(s) {


### PR DESCRIPTION
Follow-up to #51 / #53.

After #53 shipped, the **scorekeeper** highlight works correctly, but a **spectator (parent) highlight** still only showed the ★ on the score it landed on (e.g. 0-20) for ~5s — it never appeared during the rally that produced the point (0-19→0-20).

## Root cause
The scorekeeper highlight path back-propagates the ★ to the previous point's score entry (the rally) and caps the new score's entry to a 5s lit head. The parent/spectator merge in `buildOverlayEntries` only did the second half — it marked the matched entry but never lit the rally entry.

## Fix
Mirror the scorekeeper back-propagation in the parent merge: walk back to the previous point's score entry in the same set (skipping blank fillers and split-siblings of the matched score) and light it fully. A spectator tap just after a score now lights both the rally entry and the 5s celebration on the new score — identical to a scorekeeper highlight on that point.

Adds a regression test for the back-propagation. Full suite: **29/29 passing** via `node --test tests/*.test.mjs`.

https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD)_