### PR TITLE
Import: fall back to WallClock when VideoOffset_ms is empty

### DIFF
--- a/index.html
+++ b/index.html
@@ -1085,7 +1085,6 @@ function buildOverlayEntries(pointLog, syncTimestamp, teamA, teamB, matchTitle, 
 
   return entries.filter(function(e) { return e.end > e.start; });
 }
-// EXPORTERS_END — sliced by tests/harness.mjs; do not remove
 
 // --- Chroma Key shell script + Python frame renderer ---
 // Info row rendered in Python: title at x=80 (left), Set N centered, Sets A:B at x=WIDTH-80 (right)
@@ -1590,6 +1589,16 @@ function generateReadme(teamA, teamB) {
 
 
 // --- CSV parser (for import/recovery) ---
+// Parse a "HH:MM:SS" (or "H:MM") wall-clock string to milliseconds since
+// midnight. Returns null when unparseable. Used as a timeline fallback when a
+// CSV has no VideoOffset_ms (e.g. a match scored without pressing Sync).
+function parseClockToMs(clock) {
+  if (!clock) return null;
+  var m = String(clock).replace(/"/g, "").trim().match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
+  if (!m) return null;
+  var h = parseInt(m[1], 10), min = parseInt(m[2], 10), s = m[3] ? parseInt(m[3], 10) : 0;
+  return ((h * 60 + min) * 60 + s) * 1000;
+}
 function parseCSVToEntries(csvText, matchTitle) {
   var lines = csvText.trim().split("\n");
   if (lines.length < 2) return { error: "CSV must have a header row and at least one data row." };
@@ -1607,6 +1616,7 @@ function parseCSVToEntries(csvText, matchTitle) {
   var iTitle = cols.indexOf("MatchTitle");
   var iHL = cols.indexOf("Highlight");
   var iHLNote = cols.indexOf("HighlightNote");
+  var iWall = cols.indexOf("WallClock");
 
   if (iOffset === -1 || iSet === -1 || iPA === -1 || iPB === -1) {
     return { error: "CSV missing required columns: VideoOffset_ms, Set, PointsA, PointsB" };
@@ -1629,13 +1639,23 @@ function parseCSVToEntries(csvText, matchTitle) {
     break;
   }
 
+  // Build data rows. Prefer VideoOffset_ms; when it is blank (e.g. a match
+  // scored without pressing Sync, which exports an empty offset column) fall
+  // back to a timeline derived from WallClock, anchored at the first data row.
+  var wallBaseMs = null;
   var dataRows = [];
   for (var i = 1; i < lines.length; i++) {
     if (!lines[i].trim()) continue;
     var row = parseCSVRow(lines[i]);
-    var offset = parseInt(row[iOffset], 10);
-    if (isNaN(offset)) continue;
     if (iCorr !== -1 && row[iCorr] && row[iCorr].trim() === "Y") continue;
+    var offset = parseInt(row[iOffset], 10);
+    if (isNaN(offset)) {
+      var wallMs = iWall !== -1 ? parseClockToMs(row[iWall]) : null;
+      if (wallMs === null) continue;
+      if (wallBaseMs === null) wallBaseMs = wallMs;
+      offset = wallMs - wallBaseMs;
+      if (offset < 0) offset += 24 * 3600 * 1000; // match crossed midnight
+    }
     dataRows.push({
       offset_ms: offset,
       setNum: parseInt(row[iSet], 10) || 1,
@@ -1648,7 +1668,7 @@ function parseCSVToEntries(csvText, matchTitle) {
     });
   }
 
-  if (dataRows.length === 0) return { error: "No valid data rows found in CSV." };
+  if (dataRows.length === 0) return { error: "No valid data rows found in CSV (need a numeric VideoOffset_ms or a WallClock time on each point)." };
 
   // Read MatchTitle from CSV if no explicit title provided
   var csvTitle = "";
@@ -1789,6 +1809,7 @@ function parseCSVRow(line) {
   result.push(current);
   return result;
 }
+// EXPORTERS_END — sliced by tests/harness.mjs; do not remove
 
 
 // --- WebCodecs overlay generator ---

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -133,6 +133,51 @@ test("generateCSV: matchTitle is CSV-escaped (quotes doubled, commas wrapped)", 
   assert.ok(csv.includes('"He said ""go"", I went"'));
 });
 
+// ---------- parseCSVToEntries (import / recovery) ----------
+
+const NO_OFFSET_CSV = [
+  "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,Highlight,HighlightNote,MatchTitle,ScoreDisplay",
+  '1,09:32:39,,1,1,0,0,0,Slf,N,N,"","","Slf 1-0 Recuerdo"',
+  '2,09:32:40,,1,1,1,0,0,Recuerdo,N,N,"","","Slf 1-1 Recuerdo"',
+  '3,09:32:44,,1,1,0,0,0,Recuerdo,Y,N,"","","Slf 1-0 Recuerdo"', // correction row → skipped
+  '4,09:33:09,,1,2,0,0,0,Slf,N,N,"","","Slf 2-0 Recuerdo"',
+].join("\n");
+
+test("parseCSVToEntries: empty VideoOffset_ms falls back to a WallClock-derived timeline (match scored without Sync)", () => {
+  const res = helpers.parseCSVToEntries(NO_OFFSET_CSV);
+  assert.ok(!res.error, `expected a successful parse, got error: ${res.error}`);
+  assert.equal(res.teamA, "Slf");
+  assert.equal(res.teamB, "Recuerdo");
+  // 3 scoring rows (the Correction=Y row is dropped).
+  assert.equal(res.pointLog.length, 3, "correction row must be excluded");
+  // First data row anchors the timeline at 0; others are relative to it.
+  assert.equal(res.pointLog[0].timestamp, 0, "first point anchored at offset 0");
+  assert.equal(res.pointLog[1].timestamp, 1000, "09:32:40 is 1s after the anchor");
+  assert.equal(res.pointLog[2].timestamp, 30000, "09:33:09 is 30s after the anchor");
+  assert.ok(res.entries.length > 0, "overlay entries must be produced");
+});
+
+test("parseCSVToEntries: numeric VideoOffset_ms still takes precedence over WallClock", () => {
+  const csv = [
+    "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,Highlight,HighlightNote,MatchTitle,ScoreDisplay",
+    '1,09:32:39,5000,1,1,0,0,0,Slf,N,N,"","","Slf 1-0 Recuerdo"',
+    '2,09:32:40,8000,1,1,1,0,0,Recuerdo,N,N,"","","Slf 1-1 Recuerdo"',
+  ].join("\n");
+  const res = helpers.parseCSVToEntries(csv);
+  assert.ok(!res.error, `expected success, got: ${res.error}`);
+  assert.equal(res.pointLog[0].timestamp, 5000, "uses the explicit offset, not the wall clock");
+  assert.equal(res.pointLog[1].timestamp, 8000);
+});
+
+test("parseCSVToEntries: rows with neither offset nor parseable WallClock are rejected", () => {
+  const csv = [
+    "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,Highlight,HighlightNote,MatchTitle,ScoreDisplay",
+    '1,,,1,1,0,0,0,Slf,N,N,"","","Slf 1-0 Recuerdo"',
+  ].join("\n");
+  const res = helpers.parseCSVToEntries(csv);
+  assert.ok(res.error, "expected an error when no timing source is available");
+});
+
 // ---------- generateSRT / generateHighlightsSRT ----------
 
 test("generateSRT: cue indices are 1-based and contiguous", () => {


### PR DESCRIPTION
## Problem
A CSV exported from a real match was rejected on import with **"No valid data rows found in CSV."**

The match was scored **without pressing "Sync"**, so `generateCSV` wrote an empty `VideoOffset_ms` for every row (`offset = syncTimestamp ? p.timestamp - syncTimestamp : ""`). The importer (`parseCSVToEntries`) treated that column as mandatory:

```js
var offset = parseInt(row[iOffset], 10); // parseInt("") → NaN
if (isNaN(offset)) continue;             // every row skipped
```

So all rows were dropped and the file was rejected. Since the match is over, the user can't go back and create a sync point — the CSV was effectively unimportable.

## Fix
When `VideoOffset_ms` is blank, derive a relative timeline from the **`WallClock`** column (anchored so the first data row = 0), so the file imports with realistic per-point timing. Added a `parseClockToMs` helper (handles `HH:MM:SS`, tolerates a midnight rollover) and a clearer error message when a row has neither a numeric offset nor a parseable wall-clock time. Numeric `VideoOffset_ms` still takes precedence when present.

## Tests
`parseCSVToEntries`/`parseCSVRow` were previously **outside** the unit-tested `EXPORTERS` region, so the import path had no coverage. Moved both inside the sentinels (the intervening functions are hoisted declarations with no eval-time side effects) and added regression tests:
- empty-offset CSV → WallClock fallback (verifies anchor at 0 and correct relative offsets, correction rows excluded)
- numeric offsets still take precedence over WallClock
- a row with no timing source at all is rejected

Verified against the user's actual match CSV (teams `Slf` vs `Recuerdo` parse, Set 2 resumes at the correct relative offset). Full suite: **32/32 passing** via `node --test tests/*.test.mjs`.

https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD)_