### PR TITLE
v3.4.1-beta: Setup-screen sync + in-match team rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A mobile-first volleyball score tracker with timestamped point logging, multi-fo
 ## Features
 
 - **Live scoring** — Tap + / − to track points with set/match auto-detection
-- **Sync button** — Press at a known video moment (first serve or recording start) to align timestamps
+- **Sync button** — Press at a known video moment (first serve or recording start) to align timestamps; available right on the setup screen so you can start the recording and sync *before* typing team names
+- **Editable team names anywhere** — Fix a typo from the setup screen, mid-match (mirrored live to spectators), or on the match-complete screen
 - **Live Share** — Publish the match to spectators via a QR code or a link you can paste in a WhatsApp group; parents see real-time scores and submit highlights from the stands
 - **YouTube chapters** — Auto-generate a chapters file with set boundaries and highlight markers
 - **In-browser MP4 overlay** — WebCodecs generates a chroma-keyable scoreboard video right in your phone; merge it with your recording in iMovie (iPhone/Mac) or any equivalent app on Windows
@@ -20,8 +21,8 @@ A mobile-first volleyball score tracker with timestamped point logging, multi-fo
 ## Usage
 
 1. Open the app URL in Safari
-2. Enter team names and tap **Start Match**
-3. Press **Sync** when the video recording starts (or at first serve)
+2. Enter team names and tap **Start Match** — or, if you're in a hurry, press **Sync** first and fill in the names later
+3. Press **Sync** when the video recording starts (or at first serve) — from the setup screen or the match screen
 4. Tap **+** for each point scored, **★** to mark a highlight
 5. When the match ends, export in your preferred format
 
@@ -110,6 +111,7 @@ Single `index.html` file — React 18 + Babel Standalone (CDN), `mp4-muxer` ES m
 
 | Version | What shipped |
 |---|---|
+| **v3.4.1-beta** | Sync control on the setup screen (sync before typing team names), in-match team rename for scorekeeper/solo with Live Share mirroring to spectators |
 | **v3.4.0-beta** | In-app manual (`?` button → fetches README, renders Features + Usage + Live Share via marked), donate plumbing (Revolut button in BETA modal, manual, and post-export nudge), blue `?` / donate label styling, README manual sentinels (closes #42, #43, #45) |
 | **v3.3.0-beta** | New SL-on-volleyball app icon (SVG + 192/512 PNG), refreshed README, version bump |
 | **v3.2.0-beta** | Spectator previous-sets panel, parent highlight tag chips + `★ Quick` one-tap submit, score snapshot at submission time, parent highlights merged into in-video overlay, Firebase rules extended for the new fields (#39, closes #36) |

--- a/index.html
+++ b/index.html
@@ -2956,6 +2956,7 @@ function VolleyballTracker() {
   const [sharePending, setSharePending] = useState(false);
   const [parentSubmitStatus, setParentSubmitStatus] = useState(null); // { msg, isError }
   const lastParentSubmitRef = useRef(0);
+  const [showRenameRow, setShowRenameRow] = useState(false);
 
   const prevMatchOver = useRef(false);
 
@@ -3573,6 +3574,20 @@ function VolleyballTracker() {
           <div className="format-info">
             Tap <strong>+</strong> to score, <strong>&minus;</strong> to correct. Press <strong>SYNC</strong> at a known video moment to align timestamps. Match data is auto-saved.
           </div>
+          <div className={"sync-bar" + (state.syncTimestamp ? "" : " sync-bar-alert")} style={{ borderRadius: 10 }}>
+            {state.syncTimestamp ? (
+              <>
+                <div className="sync-dot on" />
+                <span className="sync-status synced">{"Synced @ " + formatClockTime(state.syncTimestamp)}</span>
+                <button className="btn btn-small" onClick={handleSync}>Re-sync</button>
+              </>
+            ) : (
+              <>
+                <span className="not-synced-badge">Not Synced</span>
+                <button className={"btn btn-small btn-sync-alert"} onClick={handleSync}>Sync Now</button>
+              </>
+            )}
+          </div>
           <button className="btn btn-primary" onClick={startMatch}>Start Match</button>
         </div>
       )}
@@ -3687,7 +3702,50 @@ function VolleyballTracker() {
                 </button>
               )
             )}
+            {state.role !== "spectator" && (
+              <button
+                className="btn btn-small"
+                style={{ marginLeft: 6, opacity: 0.7 }}
+                onClick={function() { setShowRenameRow(function(v) { return !v; }); }}
+              >
+                {showRenameRow ? "Done" : "✏ Names"}
+              </button>
+            )}
           </div>
+          {showRenameRow && state.role !== "spectator" && (
+            <div style={{ display: "flex", gap: 8, padding: "8px 16px", background: "var(--surface)", borderBottom: "1px solid var(--surface2)" }}>
+              <input
+                type="text"
+                value={state.teamA}
+                placeholder="Home"
+                style={{ flex: 1, background: "var(--surface2)", border: "1px solid var(--surface2)", borderRadius: 8, padding: "8px 10px", fontFamily: "var(--font-display)", fontSize: 14, fontWeight: 600, color: "var(--team-a)", outline: "none" }}
+                onChange={function(e) {
+                  var v = e.target.value;
+                  setState(function(s) {
+                    var next = { ...s, teamA: v };
+                    mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { teamA: v, teamB: s.teamB }); });
+                    autosaveState(next);
+                    return next;
+                  });
+                }}
+              />
+              <input
+                type="text"
+                value={state.teamB}
+                placeholder="Away"
+                style={{ flex: 1, background: "var(--surface2)", border: "1px solid var(--surface2)", borderRadius: 8, padding: "8px 10px", fontFamily: "var(--font-display)", fontSize: 14, fontWeight: 600, color: "var(--team-b)", outline: "none" }}
+                onChange={function(e) {
+                  var v = e.target.value;
+                  setState(function(s) {
+                    var next = { ...s, teamB: v };
+                    mirrorIfShared(s, function() { sync.updateMeta(s.matchId, { teamA: s.teamA, teamB: v }); });
+                    autosaveState(next);
+                    return next;
+                  });
+                }}
+              />
+            </div>
+          )}
 
           <div className="sets-bar">
             <div style={{ textAlign: "center" }}>

--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@ var MIN_LEAD = 2;
 var OVERLAY_STAR_SEC = 5;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
-var APP_VERSION = "3.4.0-beta";
+var APP_VERSION = "3.4.1-beta";
 var DONATE_URL = "https://revolut.me/jpasotto";
 
 // --- Live Share (Firebase RTDB) ---


### PR DESCRIPTION
## Summary

Two minor enhancements requested for the last-minute scorekeeping workflow, plus a version bump to **v3.4.1-beta** and matching docs.

### 1. Sync from the Setup screen
The Sync control now appears on the Setup screen (between the team inputs and **Start Match**), reusing the exact `sync-bar` markup from the match screen — unsynced shows "Sync Now", synced shows "Synced @ HH:MM:SS" + "Re-sync". This lets you start the recording and capture a sync point *before* typing team names. The captured `syncTimestamp` carries straight into the match (no re-sync needed) and anchors all exports as usual. Reuses the existing `handleSync`, including its resync-confirmation path.

### 2. Rename teams during the live match
A "✏ Names" toggle in the live match sync-bar (hidden from spectators) reveals an inline two-input rename row. Edits update state, autosave, **and mirror to Live Share spectators** via `mirrorIfShared` + `sync.updateMeta` so corrected names propagate to the bleacher view in real time. Note: editing names on the match-*complete* screen already existed; this fills the in-progress gap.

### Version & docs
- `APP_VERSION` → `3.4.1-beta` in `index.html` (the frozen `index-v3.4.html` snapshot is intentionally left at 3.4.0-beta for share-link compatibility).
- README: updated Features + Usage (rendered in-app via the manual sentinels) and added a v3.4.1-beta changelog row.

### Testing
- `node --test tests/*.test.mjs` → **32/32 pass** (changes don't touch the exporters region).
- Note: not yet exercised in a live browser; the JSX is transpiled in-browser, so a quick visual check after merge is recommended.

Closes #56

https://claude.ai/code/session_019Ti6gBHMt1XhpxhUnNKCTh

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ti6gBHMt1XhpxhUnNKCTh)_