### PR TITLE
Raise YouTube chapter rally-back cap from 30s to 60s

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,10 +296,10 @@ var OVERLAY_STAR_SEC = 5;
 // (the previous point's time in the same set), but never shifts back further
 // than this — caps long dead-time gaps such as a timeout before a set-winning
 // point (issue #58).
-var HIGHLIGHT_RALLY_LEAD_MS = 30000;
+var HIGHLIGHT_RALLY_LEAD_MS = 60000;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
-var APP_VERSION = "3.4.2-beta";
+var APP_VERSION = "3.4.3-beta";
 var DONATE_URL = "https://revolut.me/jpasotto";
 
 // --- Live Share (Firebase RTDB) ---

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -92,16 +92,16 @@ test("buildYouTubeChapterList: #58 — highlight points to the previous point's 
   }
 });
 
-test("buildYouTubeChapterList: #58 — back-shift is capped at 30s for long dead-time gaps", () => {
+test("buildYouTubeChapterList: #58 — back-shift is capped at 60s for long dead-time gaps", () => {
   const sync = 1700000000000;
   const log = [
     { timestamp: sync + 5000,   setNum: 1, pointsA: 1, pointsB: 0, highlight: false, highlightNote: null },
-    // 195s gap before the highlight (e.g. a timeout): must cap at score - 30s.
+    // 195s gap before the highlight (e.g. a timeout): must cap at score - 60s.
     { timestamp: sync + 200000, setNum: 1, pointsA: 2, pointsB: 0, highlight: true,  highlightNote: "Setter" },
   ];
   const out = helpers.buildYouTubeChapterList(log, sync, "Home", "Away", 0, []);
   const hl = out.find((c) => c.text.includes("Setter"));
-  assert.equal(hl.timeMs, 200000 - 30000, "back-shift capped to score - 30s, not the 195s-earlier point");
+  assert.equal(hl.timeMs, 200000 - 60000, "back-shift capped to score - 60s, not the 195s-earlier point");
 });
 
 test("buildYouTubeChapterList: #58 — highlight on a set's first point is not shifted into the previous set", () => {


### PR DESCRIPTION
## Why
A match with much longer rallies surfaced the 30s cap clipping real rallies. The "Rally" highlight (14-17, set 1) had a genuine **46.1s** gap to the previous point, so the 30s cap pinned its chapter 16s into the rally instead of at its start.

Rally-gap distribution for that match (within-set, n=104): median **23.1s**, avg 26.2s, p90 **46.2s**, p95 52.3s, max 120.8s — **29 of 104 gaps exceed 30s**. As a result **5 of 11 highlights** were being clipped (Invasion 37s, Bianca 35s, Rally 46s, Martina 51s, Rally-set2 60s).

The **largest gap on any highlighted point was 60.3s**, so a 60s cap restores the true rally start for essentially all real rallies while still clamping genuine dead-time gaps (timeouts / set-point pauses at 67–121s, which are never the highlighted points).

This is a no-op for the earlier short-rally match (its highlighted gaps were all under 30s, so 30s and 60s produce identical chapters there) — it only loosens the clip where it was actually biting.

## Changes
- `HIGHLIGHT_RALLY_LEAD_MS`: 30s → **60s**.
- Updated the cap regression test (asserts `score − 60s`).
- Bumps `APP_VERSION` to **3.4.3-beta**.

Full suite: **34/34 passing** via `node --test tests/*.test.mjs`.

https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD)_