### PR TITLE
Fix CSV import dropping the point before each highlight (mis-placed chapters)

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@ var OVERLAY_STAR_SEC = 5;
 var HIGHLIGHT_RALLY_LEAD_MS = 60000;
 var LOCALSTORAGE_KEY = "scorelayer_match_autosave";
 var LOCALSTORAGE_PARENT_NAME_KEY = "scorelayer_parent_name";
-var APP_VERSION = "3.4.3-beta";
+var APP_VERSION = "3.4.4-beta";
 var DONATE_URL = "https://revolut.me/jpasotto";
 
 // --- Live Share (Firebase RTDB) ---
@@ -1763,22 +1763,29 @@ function parseCSVToEntries(csvText, matchTitle) {
       });
     } else {
       var endSec = csvIsSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
-      if (endSec <= startSec) continue;
-      entries.push({
-        type: 'score',
-        start: Math.round(startSec * 1000) / 1000,
-        end:   Math.round(endSec   * 1000) / 1000,
-        score: teamA + "  " + d.pointsA + " : " + d.pointsB + "  " + teamB,
-        set_info: "Set " + d.setNum, title: title,
-        sets_score: "Sets " + setsA + ":" + setsB,
-        highlight: d.highlight || false, highlightNote: d.highlightNote || null,
-      });
-      if (csvIsSetBreak) {
+      // A point immediately followed by a same-set highlight gets a zero-length
+      // overlay entry (its rawEndSec was pulled back to its own start so the
+      // highlight's rally can cover that slot). Skip only the empty overlay
+      // entry — the point itself must still be recorded in pointLog below, or
+      // YouTube chapters / Highlights SRT lose it and mis-place later highlights
+      // (issue: import path dropped the point before each highlight).
+      if (endSec > startSec) {
         entries.push({
-          start: Math.round(endSec    * 1000) / 1000,
-          end:   Math.round(rawEndSec * 1000) / 1000,
-          blank: true,
+          type: 'score',
+          start: Math.round(startSec * 1000) / 1000,
+          end:   Math.round(endSec   * 1000) / 1000,
+          score: teamA + "  " + d.pointsA + " : " + d.pointsB + "  " + teamB,
+          set_info: "Set " + d.setNum, title: title,
+          sets_score: "Sets " + setsA + ":" + setsB,
+          highlight: d.highlight || false, highlightNote: d.highlightNote || null,
         });
+        if (csvIsSetBreak) {
+          entries.push({
+            start: Math.round(endSec    * 1000) / 1000,
+            end:   Math.round(rawEndSec * 1000) / 1000,
+            blank: true,
+          });
+        }
       }
     }
     // pointLog uses timestamp=offset_ms so generateYouTubeChapters/generateHighlightsSRT work with syncTimestamp=0

--- a/tests/exports.test.mjs
+++ b/tests/exports.test.mjs
@@ -212,6 +212,27 @@ test("parseCSVToEntries: rows with neither offset nor parseable WallClock are re
   assert.ok(res.error, "expected an error when no timing source is available");
 });
 
+test("parseCSVToEntries: the point immediately before a highlight is kept in pointLog (not dropped)", () => {
+  // The overlay rally-back gives that point a zero-length overlay entry; it must
+  // still land in pointLog, or imported YouTube chapters / Highlights SRT lose it
+  // and mis-place the highlight (the bug: import dropped the point before each ★).
+  const csv = [
+    "Index,WallClock,VideoOffset_ms,Set,PointsA,PointsB,SetsA,SetsB,ScoringTeam,Correction,Highlight,HighlightNote,MatchTitle,ScoreDisplay",
+    '1,00:00:05,5000,1,1,0,0,0,A,N,N,"","T","A 1-0 B"',
+    '2,00:00:50,50000,1,2,0,0,0,A,N,N,"","T","A 2-0 B"',   // immediately before the highlight
+    '3,00:01:00,60000,1,3,0,0,0,A,N,Y,"Spike","T","A 3-0 B"',
+  ].join("\n");
+  const res = helpers.parseCSVToEntries(csv);
+  assert.ok(!res.error, res.error);
+  assert.equal(res.pointLog.length, 3, "all 3 points kept — the 2-0 point before the ★ must not be dropped");
+  assert.equal(res.pointLog.map((p) => p.timestamp).join(","), "5000,50000,60000");
+  // With the in-between point present, the highlight chapter points to it (50s),
+  // not back to the first point / a capped offset.
+  const out = helpers.buildYouTubeChapterList(res.pointLog, 0, "A", "B", 0, []);
+  const hl = out.find((c) => c.text.includes("Spike"));
+  assert.equal(hl.timeMs, 50000, "highlight chapter points to the 2-0 point (its true rally start)");
+});
+
 // ---------- generateSRT / generateHighlightsSRT ----------
 
 test("generateSRT: cue indices are 1-based and contiguous", () => {


### PR DESCRIPTION
## Bug
Importing a match CSV and exporting YouTube chapters mis-placed highlights. Reported example: the `[Martina]` highlight (19-18, set 1) produced `16:58` instead of `17:07`.

## Root cause
In `parseCSVToEntries`, the point immediately preceding a same-set highlight gets a **zero-length overlay entry** (its `rawEndSec` is intentionally pulled back to its own start so the highlight's rally can cover that slot). The guard

```js
var endSec = csvIsSetBreak ? (startSec + rawEndSec) / 2 : rawEndSec;
if (endSec <= startSec) continue;   // <-- also skipped pointLog.push below
```

used `continue`, which skipped the **entire** iteration — including the `pointLog.push` at the bottom of the loop. So every point sitting just before a `★` was **dropped from the pointLog** that feeds YouTube chapters and Highlights SRT.

With that point missing, the highlight's "previous point" became one further back (e.g. Martina's became 17-18, 70s away instead of 18-18, 51s away), which tripped the 60s rally-back cap and pinned the chapter to `score − 60s`.

For the reported match the import dropped **9 of 107 points**. (Live in-app scoring was unaffected — it builds the pointLog directly; only the CSV-import path had this bug.)

## Fix
Skip only the empty overlay **entry**, not the whole iteration — the point is always recorded in `pointLog`:

```js
if (endSec > startSec) {
  entries.push({ ...score entry... });
  if (csvIsSetBreak) entries.push({ ...blank... });
}
// pointLog.push(...) now always runs
```

After the fix: import keeps all 107 points, and Martina resolves to its true previous point (18-18) → **17:07**.

## Tests
Adds a regression test exercising the full import path: the point before a `★` is retained in `pointLog`, and the highlight chapter lands on that point's time rather than a dropped-point / capped offset. Full suite: **35/35 passing** via `node --test tests/*.test.mjs`.

## Other
Bumps `APP_VERSION` to **3.4.4-beta**.

https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2iopb45hdVGmUsLTEpafD)_